### PR TITLE
Update intro.md to add rootless (Podman) local-only & auto-update

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -130,6 +130,56 @@ title: "🚀 Getting Started"
   ./run-compose.sh --enable-gpu --build
   ```
 
+## Installing with Podman
+
+<details>
+<summary>Rootless (Podman) local-only Open WebUI with Systemd service and auto-update</summary>
+
+- **Important:** Consult the Docker documentation because much of the configuration and syntax is interchangeable with [Podman](https://github.com/containers/podman). See also [rootless_tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md). This example requires the [slirp4netns](https://github.com/rootless-containers/slirp4netns) network backend to facilitate server listen and Ollama communication over localhost only.
+
+1. Pull the latest image:
+   ```bash
+   podman pull ghcr.io/open-webui/open-webui:main
+   ```
+2. Create a new container using desired configuration:
+
+   **Note:** `-p 127.0.0.1:3000:8080` ensures that we listen only on localhost, `--network slirp4netns:allow_host_loopback=true` permits the container to access Ollama when it also listens strictly on localhost. `--add-host=ollama.local:10.0.2.2 --env 'OLLAMA_API_BASE_URL=http://ollama.local:11434/api'` adds a hosts record to the container and configures open-webui to use the friendly hostname. `10.0.2.2` is the default slirp4netns address used for localhost mapping. `--env 'ANONYMIZED_TELEMETRY=False'` isn't necessary since Chroma telemetry has been disabled in the code but is included as an example.
+
+   ```bash
+   podman create -p 127.0.0.1:3000:8080 --network slirp4netns:allow_host_loopback=true --add-host=ollama.local:10.0.2.2 --env 'OLLAMA_API_BASE_URL=http://ollama.local:11434/api' --env 'ANONYMIZED_TELEMETRY=False' -v open-webui:/app/backend/data --label io.containers.autoupdate=registry --name open-webui ghcr.io/open-webui/open-webui:main
+   ```
+
+3. Prepare for systemd user service:
+   ```bash
+   mkdir -p ~/.config/systemd/user/
+   ```
+4. Generate user service with Podman:
+   ```bash
+   podman generate systemd --new open-webui > ~/.config/systemd/user/open-webui.service
+   ```
+5. Reload systemd configuration:
+   ```bash
+   systemctl --user daemon-reload
+   ```
+6. Enable and validate new service:
+   ```bash
+   systemctl --user enable open-webui.service
+   systemctl --user start open-webui.service
+   systemctl --user status open-webui.service
+   ```
+7. Enable and validate Podman auto-update:
+   ```bash
+   systemctl --user enable podman-auto-update.timer
+   systemctl --user enable podman-auto-update.service
+   systemctl --user status podman-auto-update.timer
+   ```
+   Dry run with the following command (omit `--dry-run` to force an update):
+   ```bash
+   podman auto-update --dry-run
+   ```
+
+</details>
+
 ### Alternative Installation Methods
 
 For other ways to install, like using Kustomize or Helm, check out [INSTALLATION](/getting-started/installation). Join our [Open WebUI Discord community](https://discord.gg/5rJgQTnV4s) for more help and information.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -75,6 +75,53 @@ Don't forget to explore our sibling project, [Open WebUI Community](https://open
   docker run -d -p 3000:8080 -e OLLAMA_API_BASE_URL=https://example.com/api -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
   ```
 
+## Installing with Podman
+<details>
+<summary>Rootless (Podman) local-only Open WebUI with Systemd service and auto-update</summary>
+
+- **Important:** Consult the Docker documentation because much of the configuration and syntax is interchangeable with [Podman](https://github.com/containers/podman). See also [rootless_tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md). This example requires the [slirp4netns](https://github.com/rootless-containers/slirp4netns) network backend to facilitate server listen and Ollama communication over localhost only.
+
+1. Pull the latest image:
+   ```bash
+   podman pull ghcr.io/open-webui/open-webui:main
+   ```
+2. Create a new container using desired configuration:
+
+   **Note:** `-p 127.0.0.1:3000:8080` ensures that we listen only on localhost, `--network slirp4netns:allow_host_loopback=true` permits the container to access Ollama when it also listens strictly on localhost. `--add-host=ollama.local:10.0.2.2 --env 'OLLAMA_API_BASE_URL=http://ollama.local:11434/api'` adds a hosts record to the container and configures open-webui to use the friendly hostname. `10.0.2.2` is the default slirp4netns address used for localhost mapping. `--env 'ANONYMIZED_TELEMETRY=False'` isn't necessary since Chroma telemetry has been disabled in the code but is included as an example.
+   ```bash
+   podman create -p 127.0.0.1:3000:8080 --network slirp4netns:allow_host_loopback=true --add-host=ollama.local:10.0.2.2 --env 'OLLAMA_API_BASE_URL=http://ollama.local:11434/api' --env 'ANONYMIZED_TELEMETRY=False' -v open-webui:/app/backend/data --label io.containers.autoupdate=registry --name open-webui ghcr.io/open-webui/open-webui:main
+   ```
+4. Prepare for systemd user service:
+   ```bash
+   mkdir -p ~/.config/systemd/user/
+   ```
+5. Generate user service with Podman:
+   ```bash
+   podman generate systemd --new open-webui > ~/.config/systemd/user/open-webui.service
+   ```
+6. Reload systemd configuration:
+   ```bash
+   systemctl --user daemon-reload
+   ```
+7. Enable and validate new service:
+   ```bash
+   systemctl --user enable open-webui.service
+   systemctl --user start open-webui.service
+   systemctl --user status open-webui.service
+   ```
+8. Enable and validate Podman auto-update:
+   ```bash
+   systemctl --user enable podman-auto-update.timer
+   systemctl --user enable podman-auto-update.service
+   systemctl --user status podman-auto-update.timer
+   ```
+   Dry run with the following command (omit `--dry-run` to force an update):
+   ```bash
+   podman auto-update --dry-run
+   ```
+
+</details>
+
 ## Troubleshooting
 
 If you're facing various issues like "Open WebUI: Server Connection Error", see [TROUBLESHOOTING](/getting-started/troubleshooting) for information on how to troubleshoot and/or join our [Open WebUI Discord community](https://discord.gg/5rJgQTnV4s).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -75,53 +75,6 @@ Don't forget to explore our sibling project, [Open WebUI Community](https://open
   docker run -d -p 3000:8080 -e OLLAMA_API_BASE_URL=https://example.com/api -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
   ```
 
-## Installing with Podman
-<details>
-<summary>Rootless (Podman) local-only Open WebUI with Systemd service and auto-update</summary>
-
-- **Important:** Consult the Docker documentation because much of the configuration and syntax is interchangeable with [Podman](https://github.com/containers/podman). See also [rootless_tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md). This example requires the [slirp4netns](https://github.com/rootless-containers/slirp4netns) network backend to facilitate server listen and Ollama communication over localhost only.
-
-1. Pull the latest image:
-   ```bash
-   podman pull ghcr.io/open-webui/open-webui:main
-   ```
-2. Create a new container using desired configuration:
-
-   **Note:** `-p 127.0.0.1:3000:8080` ensures that we listen only on localhost, `--network slirp4netns:allow_host_loopback=true` permits the container to access Ollama when it also listens strictly on localhost. `--add-host=ollama.local:10.0.2.2 --env 'OLLAMA_API_BASE_URL=http://ollama.local:11434/api'` adds a hosts record to the container and configures open-webui to use the friendly hostname. `10.0.2.2` is the default slirp4netns address used for localhost mapping. `--env 'ANONYMIZED_TELEMETRY=False'` isn't necessary since Chroma telemetry has been disabled in the code but is included as an example.
-   ```bash
-   podman create -p 127.0.0.1:3000:8080 --network slirp4netns:allow_host_loopback=true --add-host=ollama.local:10.0.2.2 --env 'OLLAMA_API_BASE_URL=http://ollama.local:11434/api' --env 'ANONYMIZED_TELEMETRY=False' -v open-webui:/app/backend/data --label io.containers.autoupdate=registry --name open-webui ghcr.io/open-webui/open-webui:main
-   ```
-4. Prepare for systemd user service:
-   ```bash
-   mkdir -p ~/.config/systemd/user/
-   ```
-5. Generate user service with Podman:
-   ```bash
-   podman generate systemd --new open-webui > ~/.config/systemd/user/open-webui.service
-   ```
-6. Reload systemd configuration:
-   ```bash
-   systemctl --user daemon-reload
-   ```
-7. Enable and validate new service:
-   ```bash
-   systemctl --user enable open-webui.service
-   systemctl --user start open-webui.service
-   systemctl --user status open-webui.service
-   ```
-8. Enable and validate Podman auto-update:
-   ```bash
-   systemctl --user enable podman-auto-update.timer
-   systemctl --user enable podman-auto-update.service
-   systemctl --user status podman-auto-update.timer
-   ```
-   Dry run with the following command (omit `--dry-run` to force an update):
-   ```bash
-   podman auto-update --dry-run
-   ```
-
-</details>
-
 ## Troubleshooting
 
 If you're facing various issues like "Open WebUI: Server Connection Error", see [TROUBLESHOOTING](/getting-started/troubleshooting) for information on how to troubleshoot and/or join our [Open WebUI Discord community](https://discord.gg/5rJgQTnV4s).


### PR DESCRIPTION
Add instructions for configuration of rootless (Podman) local-only Open WebUI with Systemd service and auto-update capability. Relates to open-webui/docs#11 as an alternative solution. See also open-webui/open-webui#877