### PR TITLE
Add OpenAI DALL·E Instructions, Password Reset, More FAQs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -44,4 +44,4 @@ By choosing the official Docker package, you benefit from consistent behavior ac
 
 Everything you need to run Open WebUI, including your data, remains within your control and your server environment, emphasizing our commitment to your privacy and security. For instructions on installing the official Docker package, please refer to the [Install Docker Engine](https://docs.docker.com/engine/install/) guide on Docker's official documentation site.
 
-#### If you have any further questions or concerns, please don't hesitate to reach out on our [GitHub Issues page](https://github.com/open-webui/open-webui/issues) or our [Discord channel](https://discord.gg/5rJgQTnV4s) for more help and information.
+#### If you have any further questions or concerns, please out our [GitHub Issues page](https://github.com/open-webui/open-webui/issues) or our [Discord channel](https://discord.gg/5rJgQTnV4s) for more help and information.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -52,7 +52,7 @@ Everything you need to run Open WebUI, including your data, remains within your 
 
 **A:** The functionality of Speech-to-Text (STT) and Text-to-Speech (TTS) services in your deployment may require HTTPS to operate correctly. Modern browsers enforce security measures that restrict certain features, including STT and TTS, to only work under secure HTTPS connections. If your deployment is not configured to use HTTPS, these services might not function as expected. Ensuring your deployment is accessible over HTTPS can resolve these issues, enabling full functionality of STT/TTS features.
 
-#### **Q: Why doesn't the project include HTTPS support?**
+#### **Q: Why doesn't the WebUI include HTTPS support built-in?**
 
 **A:** While we understand the desire for an all-in-one solution that includes HTTPS support, we believe such an approach wouldn't adequately serve the diverse needs of our user base. Implementing HTTPS directly within the project could limit flexibility and may not align with the specific requirements or preferences of all users. To ensure that everyone can tailor their setup to their unique environment, we leave the implementation of HTTPS termination to the users for their production deployments. This decision allows for greater adaptability and customization. Though we don't offer official documentation on setting up HTTPS, community members may provide guidance upon request, sharing insights and suggestions based on their experiences.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -44,4 +44,4 @@ By choosing the official Docker package, you benefit from consistent behavior ac
 
 Everything you need to run Open WebUI, including your data, remains within your control and your server environment, emphasizing our commitment to your privacy and security. For instructions on installing the official Docker package, please refer to the [Install Docker Engine](https://docs.docker.com/engine/install/) guide on Docker's official documentation site.
 
-If you have any further questions or concerns, please don't hesitate to reach out! 🛡️
+#### If you have any further questions or concerns, please don't hesitate to reach out on our [GitHub Issues page](https://github.com/open-webui/open-webui/issues) or our [Discord channel](https://discord.gg/5rJgQTnV4s) for more help and information.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -56,4 +56,16 @@ Everything you need to run Open WebUI, including your data, remains within your 
 
 **A:** While we understand the desire for an all-in-one solution that includes HTTPS support, we believe such an approach wouldn't adequately serve the diverse needs of our user base. Implementing HTTPS directly within the project could limit flexibility and may not align with the specific requirements or preferences of all users. To ensure that everyone can tailor their setup to their unique environment, we leave the implementation of HTTPS termination to the users for their production deployments. This decision allows for greater adaptability and customization. Though we don't offer official documentation on setting up HTTPS, community members may provide guidance upon request, sharing insights and suggestions based on their experiences.
 
+#### **Q: I updated/restarted/installed some new software and now my WebUI isn't working anymore!**
+
+**A:** If your Open WebUI isn't launching post-update or installation of new software, it's likely related to a direct installation approach, especially if you didn't use a virtual environment for your backend dependencies. Direct installations can be sensitive to changes in the system's environment, such as updates or new installations that alter existing dependencies. To avoid conflicts and ensure stability, we recommend using a virtual environment for managing the `requirements.txt` dependencies of your backend. This isolates your Open WebUI dependencies from other system packages, minimizing the risk of such issues.
+
+#### **Q: I updated/restarted and now my login isn't working anymore, I had to create a new account and all my chats are gone.**
+
+**A:** This issue typically arises when a Docker container is created without mounting a volume for `/app/backend/data` or if the designated Open WebUI volume (usually named `open-webui` in our examples) was unintentionally deleted. Docker volumes are crucial for persisting your data across container lifecycles. If you find yourself needing to create a new account after a restart, it's likely you've initiated a new container without attaching the existing volume where your data resides. Ensure that your Docker run command includes a volume mount pointing to the correct data location to prevent data loss.
+
+#### **Q: I tried to login and couldn't, made a new account and now I'm being told my account needs to be activated by an admin.**
+
+**A:** This situation occurs when you forget the password for the initial admin account created during the first setup. The first account is automatically designated as the admin account. Creating a new account without access to the admin account will result in the need for admin activation. Avoiding the loss of the initial admin account credentials is crucial for seamless access and management of Open WebUI.
+
 #### If you have any further questions or concerns, please out our [GitHub Issues page](https://github.com/open-webui/open-webui/issues) or our [Discord channel](https://discord.gg/5rJgQTnV4s) for more help and information.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -86,6 +86,6 @@ Everything you need to run Open WebUI, including your data, remains within your 
 
 #### **Q: I tried to login and couldn't, made a new account and now I'm being told my account needs to be activated by an admin.**
 
-**A:** This situation occurs when you forget the password for the initial admin account created during the first setup. The first account is automatically designated as the admin account. Creating a new account without access to the admin account will result in the need for admin activation. Avoiding the loss of the initial admin account credentials is crucial for seamless access and management of Open WebUI.
+**A:** This situation occurs when you forget the password for the initial admin account created during the first setup. The first account is automatically designated as the admin account. Creating a new account without access to the admin account will result in the need for admin activation. Avoiding the loss of the initial admin account credentials is crucial for seamless access and management of Open WebUI. See the [Resetting the Admin Password](getting-started/troubleshooting#reset-admin-password) guide for instructions on recovering the admin account.
 
 #### If you have any further questions or concerns, please out our [GitHub Issues page](https://github.com/open-webui/open-webui/issues) or our [Discord channel](https://discord.gg/5rJgQTnV4s) for more help and information.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -44,4 +44,12 @@ By choosing the official Docker package, you benefit from consistent behavior ac
 
 Everything you need to run Open WebUI, including your data, remains within your control and your server environment, emphasizing our commitment to your privacy and security. For instructions on installing the official Docker package, please refer to the [Install Docker Engine](https://docs.docker.com/engine/install/) guide on Docker's official documentation site.
 
+#### **Q: Is GPU support available in Docker?**
+
+**A:** GPU support in Docker is available but varies depending on the platform. Officially, GPU support is provided in Docker for Windows and Docker Engine on Linux. Other platforms, such as Docker Desktop for Linux and MacOS, do not currently offer GPU support. This limitation is important to consider for applications requiring GPU acceleration. For the best experience and to utilize GPU capabilities, we recommend using Docker on platforms that officially support GPU integration.
+
+#### **Q: Why doesn't the project include HTTPS support?**
+
+**A:** While we understand the desire for an all-in-one solution that includes HTTPS support, we believe such an approach wouldn't adequately serve the diverse needs of our user base. Implementing HTTPS directly within the project could limit flexibility and may not align with the specific requirements or preferences of all users. To ensure that everyone can tailor their setup to their unique environment, we leave the implementation of HTTPS termination to the users for their production deployments. This decision allows for greater adaptability and customization. Though we don't offer official documentation on setting up HTTPS, community members may provide guidance upon request, sharing insights and suggestions based on their experiences.
+
 #### If you have any further questions or concerns, please out our [GitHub Issues page](https://github.com/open-webui/open-webui/issues) or our [Discord channel](https://discord.gg/5rJgQTnV4s) for more help and information.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,19 +7,19 @@ title: "📋 FAQ"
 
 ### Table of Contents
 
-- [Q:  Why am I asked to sign up? Where are my data being sent to?](faq#q-why-am-i-asked-to-sign-up-where-are-my-data-being-sent-to)
-- [Q: Why can't my Docker container connect to services on the host using `localhost`?](faq#q-why-cant-my-docker-container-connect-to-services-on-the-host-using-localhost)
-- [Q: How do I make my host's services accessible to Docker containers?](faq#q-how-do-i-make-my-hosts-services-accessible-to-docker-containers)
-- [Q: Why isn't my Open WebUI updating? I've re-pulled/restarted the container, and nothing changed.](faq#q-why-isnt-my-open-webui-updating-ive-re-pulledrestarted-the-container-and-nothing-changed)
-- [Q: Wait, delete my container, won't I lose my data?](faq#q-wait-delete-my-container-wont-i-lose-my-data)
-- [Q: Should I use the distro-packaged Docker or the official Docker package?](faq#q-should-i-use-the-distro-packaged-docker-or-the-official-docker-package)
-- [Q: Is GPU support available in Docker?](faq#q-is-gpu-support-available-in-docker)
-- [Q: Why does the WebUI project emphasize the use of Docker?](faq#q-why-does-the-webui-project-emphasize-the-use-of-docker)
-- [Q: Why doesn't STT/TTS work in my deployment?](faq#q-why-doesnt-stttts-work-in-my-deployment)
-- [Q: Why doesn't the WebUI include HTTPS support built-in?](faq#q-why-doesnt-the-webui-include-https-support-built-in)
-- [Q: I updated/restarted/installed some new software and now my WebUI isn't working anymore!](faq#q-i-updatedrestartedinstalled-some-new-software-and-now-my-webui-isnt-working-anymore)
-- [Q: I updated/restarted and now my login isn't working anymore, I had to create a new account and all my chats are gone.](faq#q-i-updatedrestarted-and-now-my-login-isnt-working-anymore-i-had-to-create-a-new-account-and-all-my-chats-are-gone)
-- [Q: I tried to login and couldn't, made a new account and now I'm being told my account needs to be activated by an admin.](faq#q-i-tried-to-login-and-couldnt-made-a-new-account-and-now-im-being-told-my-account-needs-to-be-activated-by-an-admin)
+- [Q:  Why am I asked to sign up? Where are my data being sent to?](#q-why-am-i-asked-to-sign-up-where-are-my-data-being-sent-to)
+- [Q: Why can't my Docker container connect to services on the host using `localhost`?](#q-why-cant-my-docker-container-connect-to-services-on-the-host-using-localhost)
+- [Q: How do I make my host's services accessible to Docker containers?](#q-how-do-i-make-my-hosts-services-accessible-to-docker-containers)
+- [Q: Why isn't my Open WebUI updating? I've re-pulled/restarted the container, and nothing changed.](#q-why-isnt-my-open-webui-updating-ive-re-pulledrestarted-the-container-and-nothing-changed)
+- [Q: Wait, delete my container, won't I lose my data?](#q-wait-delete-my-container-wont-i-lose-my-data)
+- [Q: Should I use the distro-packaged Docker or the official Docker package?](#q-should-i-use-the-distro-packaged-docker-or-the-official-docker-package)
+- [Q: Is GPU support available in Docker?](#q-is-gpu-support-available-in-docker)
+- [Q: Why does the WebUI project emphasize the use of Docker?](#q-why-does-the-webui-project-emphasize-the-use-of-docker)
+- [Q: Why doesn't STT/TTS work in my deployment?](#q-why-doesnt-stttts-work-in-my-deployment)
+- [Q: Why doesn't the WebUI include HTTPS support built-in?](#q-why-doesnt-the-webui-include-https-support-built-in)
+- [Q: I updated/restarted/installed some new software and now my WebUI isn't working anymore!](#q-i-updatedrestartedinstalled-some-new-software-and-now-my-webui-isnt-working-anymore)
+- [Q: I updated/restarted and now my login isn't working anymore, I had to create a new account and all my chats are gone.](#q-i-updatedrestarted-and-now-my-login-isnt-working-anymore-i-had-to-create-a-new-account-and-all-my-chats-are-gone)
+- [Q: I tried to login and couldn't, made a new account and now I'm being told my account needs to be activated by an admin.](#q-i-tried-to-login-and-couldnt-made-a-new-account-and-now-im-being-told-my-account-needs-to-be-activated-by-an-admin)
 
 #### **Q: Why am I asked to sign up? Where are my data being sent to?**
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -48,6 +48,10 @@ Everything you need to run Open WebUI, including your data, remains within your 
 
 **A:** GPU support in Docker is available but varies depending on the platform. Officially, GPU support is provided in Docker for Windows and Docker Engine on Linux. Other platforms, such as Docker Desktop for Linux and MacOS, do not currently offer GPU support. This limitation is important to consider for applications requiring GPU acceleration. For the best experience and to utilize GPU capabilities, we recommend using Docker on platforms that officially support GPU integration.
 
+#### **Q: Why doesn't STT/TTS work in my deployment?**
+
+**A:** The functionality of Speech-to-Text (STT) and Text-to-Speech (TTS) services in your deployment may require HTTPS to operate correctly. Modern browsers enforce security measures that restrict certain features, including STT and TTS, to only work under secure HTTPS connections. If your deployment is not configured to use HTTPS, these services might not function as expected. Ensuring your deployment is accessible over HTTPS can resolve these issues, enabling full functionality of STT/TTS features.
+
 #### **Q: Why doesn't the project include HTTPS support?**
 
 **A:** While we understand the desire for an all-in-one solution that includes HTTPS support, we believe such an approach wouldn't adequately serve the diverse needs of our user base. Implementing HTTPS directly within the project could limit flexibility and may not align with the specific requirements or preferences of all users. To ensure that everyone can tailor their setup to their unique environment, we leave the implementation of HTTPS termination to the users for their production deployments. This decision allows for greater adaptability and customization. Though we don't offer official documentation on setting up HTTPS, community members may provide guidance upon request, sharing insights and suggestions based on their experiences.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -48,6 +48,10 @@ Everything you need to run Open WebUI, including your data, remains within your 
 
 **A:** GPU support in Docker is available but varies depending on the platform. Officially, GPU support is provided in Docker for Windows and Docker Engine on Linux. Other platforms, such as Docker Desktop for Linux and MacOS, do not currently offer GPU support. This limitation is important to consider for applications requiring GPU acceleration. For the best experience and to utilize GPU capabilities, we recommend using Docker on platforms that officially support GPU integration.
 
+#### **Q: Why does the WebUI project emphasize the use of Docker?**
+
+**A:** The decision to use Docker stems from its ability to ensure consistency, isolate dependencies, and simplify deployment across different environments. Docker minimizes compatibility issues and streamlines the process of getting the WebUI up and running, regardless of the underlying system. It's a strategic choice by the project maintainers to harness these benefits, acknowledging that while Docker has a learning curve, the advantages for deployment and maintenance are significant. We understand Docker might not be everyone's preference; however, this approach is central to our project's design and operational efficiency. We view the project's commitment to Docker as a fundamental aspect and encourage those looking for different deployment methods to explore community-driven alternatives.
+
 #### **Q: Why doesn't STT/TTS work in my deployment?**
 
 **A:** The functionality of Speech-to-Text (STT) and Text-to-Speech (TTS) services in your deployment may require HTTPS to operate correctly. Modern browsers enforce security measures that restrict certain features, including STT and TTS, to only work under secure HTTPS connections. If your deployment is not configured to use HTTPS, these services might not function as expected. Ensuring your deployment is accessible over HTTPS can resolve these issues, enabling full functionality of STT/TTS features.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,6 +5,22 @@ title: "📋 FAQ"
 
 # 📋 Frequently Asked Questions
 
+### Table of Contents
+
+- [Q:  Why am I asked to sign up? Where are my data being sent to?](faq#q-why-am-i-asked-to-sign-up-where-are-my-data-being-sent-to)
+- [Q: Why can't my Docker container connect to services on the host using `localhost`?](faq#q-why-cant-my-docker-container-connect-to-services-on-the-host-using-localhost)
+- [Q: How do I make my host's services accessible to Docker containers?](faq#q-how-do-i-make-my-hosts-services-accessible-to-docker-containers)
+- [Q: Why isn't my Open WebUI updating? I've re-pulled/restarted the container, and nothing changed.](faq#q-why-isnt-my-open-webui-updating-ive-re-pulledrestarted-the-container-and-nothing-changed)
+- [Q: Wait, delete my container, won't I lose my data?](faq#q-wait-delete-my-container-wont-i-lose-my-data)
+- [Q: Should I use the distro-packaged Docker or the official Docker package?](faq#q-should-i-use-the-distro-packaged-docker-or-the-official-docker-package)
+- [Q: Is GPU support available in Docker?](faq#q-is-gpu-support-available-in-docker)
+- [Q: Why does the WebUI project emphasize the use of Docker?](faq#q-why-does-the-webui-project-emphasize-the-use-of-docker)
+- [Q: Why doesn't STT/TTS work in my deployment?](faq#q-why-doesnt-stttts-work-in-my-deployment)
+- [Q: Why doesn't the WebUI include HTTPS support built-in?](faq#q-why-doesnt-the-webui-include-https-support-built-in)
+- [Q: I updated/restarted/installed some new software and now my WebUI isn't working anymore!](faq#q-i-updatedrestartedinstalled-some-new-software-and-now-my-webui-isnt-working-anymore)
+- [Q: I updated/restarted and now my login isn't working anymore, I had to create a new account and all my chats are gone.](faq#q-i-updatedrestarted-and-now-my-login-isnt-working-anymore-i-had-to-create-a-new-account-and-all-my-chats-are-gone)
+- [Q: I tried to login and couldn't, made a new account and now I'm being told my account needs to be activated by an admin.](faq#q-i-tried-to-login-and-couldnt-made-a-new-account-and-now-im-being-told-my-account-needs-to-be-activated-by-an-admin)
+
 #### **Q: Why am I asked to sign up? Where are my data being sent to?**
 
 **A:** We require you to sign up to become the admin user for enhanced security. This ensures that if the Open WebUI is ever exposed to external access, your data remains secure. It's important to note that everything is kept local. We do not collect your data. When you sign up, all information stays within your server and never leaves your device. Your privacy and security are our top priorities, ensuring that your data remains under your control at all times.

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -46,7 +46,7 @@ To reset the admin password for Open WebUI in a Docker deployment, generate a bc
 
 2. **Update password in Docker** (replace `HASH` and `admin@example.com`):
    ```bash
-   docker run --rm -v open-webui:/data alpine/socat EXEC:"bash -c 'apk add sqlite && echo UPDATE auth SET password='\''HASH'\'' WHERE email='\''admin@example.com'\''; | sqlite3 /data/ollama.db'", STDIO
+   docker run --rm -v open-webui:/data alpine/socat EXEC:"bash -c 'apk add sqlite && echo UPDATE auth SET password='\''HASH'\'' WHERE email='\''admin@example.com'\''; | sqlite3 /data/webui.db'", STDIO
    ```
 
 ### Reset Admin Password Locally

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -30,3 +30,35 @@ docker run -d --network=host -v open-webui:/app/backend/data -e OLLAMA_BASE_URL=
    - Confirm that the Ollama Server URL is correctly set to `[OLLAMA URL]` (e.g., `http://localhost:11434`).
 
 By following these enhanced troubleshooting steps, connection issues should be effectively resolved. For further assistance or queries, feel free to reach out to us on our community Discord.
+
+## Reset Admin Password
+
+If you've forgotten your admin password, you can reset it by following these steps:
+
+### Reset Admin Password in Docker
+
+To reset the admin password for Open WebUI in a Docker deployment, generate a bcrypt hash of your new password and run a Docker command to update the database. Replace `your-new-password` with the desired password and execute:
+
+1. **Generate bcrypt hash** (local machine):
+   ```bash
+   htpasswd -bnBC 10 "" your-new-password | tr -d ':\n'
+   ```
+
+2. **Update password in Docker** (replace `HASH` and `admin@example.com`):
+   ```bash
+   docker run --rm -v open-webui:/data alpine/socat EXEC:"bash -c 'apk add sqlite && echo UPDATE auth SET password='\''HASH'\'' WHERE email='\''admin@example.com'\''; | sqlite3 /data/ollama.db'", STDIO
+   ```
+
+### Reset Admin Password Locally
+
+For local installations of Open WebUI, navigate to the `open-webui` directory and update the password in the `backend/data/webui.db` database.
+
+1. **Generate bcrypt hash** (local machine):
+   ```bash
+   htpasswd -bnBC 10 "" your-new-password | tr -d ':\n'
+   ```
+
+2. **Update password locally** (replace `HASH` and `admin@example.com`):
+   ```bash
+   sqlite3 backend/data/webui.db "UPDATE auth SET password='HASH' WHERE email='admin@example.com';"
+   ```

--- a/docs/tutorial/images.md
+++ b/docs/tutorial/images.md
@@ -1,8 +1,12 @@
 # Image Generation
 
-Open WebUI now supports image generation through the **AUTOMATIC1111** [API](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/API). To set this up, follow these steps:
+Open WebUI now supports image generation through two backends: **AUTOMATIC1111** and **OpenAI DALL·E**. This guide will help you set up and use both options.
 
-## Initial Setup
+## AUTOMATIC1111
+
+Open WebUI supports image generation through the **AUTOMATIC1111** [API](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/API). Follow these steps to get started:
+
+### Initial Setup
 
 1. Ensure that you have [AUTOMATIC1111](https://github.com/AUTOMATIC1111/stable-diffusion-webui) installed.
 2. Launch AUTOMATIC1111 with additional flags to enable API access:
@@ -11,14 +15,31 @@ Open WebUI now supports image generation through the **AUTOMATIC1111** [API](htt
    ```
    For Docker installations of Open WebUI, use the `--listen` flag to allow connections outside of localhost.
 
-## Configuring Open WebUI
+### Configuring Open WebUI
 
 1. In Open WebUI, navigate to **Settings > Images**.
-2. In the API URL field, enter the address where AUTOMATIC1111's API is accessible, following this format:
+2. In the API URL field, enter the address where AUTOMATIC1111's API is accessible:
    ```
    http://<your_automatic1111_address>:7860
    ```
-   If you're running a Docker installation of Open WebUI and AUTOMATIC1111 on the same host, replace `<your_automatic1111_address>` with `host.docker.internal`.
+   If you're running a Docker installation of Open WebUI and AUTOMATIC1111 on the same host, use `host.docker.internal` as your address.
+
+## OpenAI DALL·E
+
+Open WebUI also supports image generation through the **OpenAI DALL·E APIs**. This option now includes a selector for choosing between DALL·E 2 and DALL·E 3, each supporting different image sizes.
+
+### Initial Setup
+
+1. Obtain an [API key](https://platform.openai.com/api-keys) from OpenAI.
+
+### Configuring Open WebUI
+
+1. In Open WebUI, navigate to **Settings > Images**.
+2. Select **OpenAI** as your image generation backend.
+3. Enter your OpenAI API key.
+4. Choose the DALL·E model you wish to use. Note that image size options will depend on the selected model:
+   - **DALL·E 2**: Supports `256x256`, `512x512`, or `1024x1024` images.
+   - **DALL·E 3**: Supports `1024x1024`, `1792x1024`, or `1024x1792` images.
 
 ## Using Image Generation
 
@@ -26,5 +47,3 @@ Open WebUI now supports image generation through the **AUTOMATIC1111** [API](htt
 
 1. First, use a text generation model to write a prompt for image generation.
 2. After the response has finished, you can click the Picture icon to generate an image.
-
-Please note that, as of now, only AUTOMATIC1111's API is supported for image generation within Open WebUI.

--- a/docs/tutorial/openai.md
+++ b/docs/tutorial/openai.md
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 2
-title: "OpenAI API"
+title: "OpenAI API Endpoints"
 ---
 
-# OpenAI Connections
+# OpenAI API Endpoints
 
 In this tutorial, we will demonstrate how to configure multiple OpenAI (or compatible) API endpoints using environment variables. This setup allows you to easily switch between different API providers or use multiple providers simultaneously, while keeping your configuration between container updates, rebuilds or redeployments.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -100,6 +100,10 @@ const config = {
                 label: "Getting Started",
                 to: "getting-started",
               },
+              {
+                label: "Tutorial",
+                to: "tutorial",
+              }
             ],
           },
           {
@@ -123,9 +127,17 @@ const config = {
             title: "More",
             items: [
               {
+                label: "Release Notes",
+                to: "https://github.com/open-webui/open-webui/blob/main/CHANGELOG.md",
+              },
+              {
                 label: "About",
                 to: "https://openwebui.com",
               },
+              {
+                label: "Research",
+                to: "research",
+              }
             ],
           },
         ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -103,6 +103,10 @@ const config = {
               {
                 label: "Tutorial",
                 to: "tutorial",
+              },
+              {
+                label: "FAQ",
+                to: "faq"
               }
             ],
           },


### PR DESCRIPTION
This PR enhances the image generation tutorial by adding comprehensive instructions for utilizing the OpenAI DALL·E option within Open WebUI. With the introduction of a new backend selector, users can now opt between the AUTOMATIC1111 and OpenAI DALL·E backends for image generation. Specifically for OpenAI DALL·E, the update includes detailed steps on model selection (DALL·E 2 or DALL·E 3), API key entry, and choosing the appropriate image size based on the model. This improvement aims to provide users with a thorough understanding and ease of use for both available image generation backends.

Additionally, I've made minor updates including the renaming of the "OpenAI Connections" tutorial to "OpenAI API Endpoints," and the inclusion of footer navigation links to the "Tutorial", "FAQ", and "Research" pages, as well as the git `CHANGELOG.md` file, further enhancing site navigability and resource accessibility.
