### PR TITLE
Example Podman command in troubleshooting.md

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -24,6 +24,14 @@ If you're experiencing connection issues with the SSL error of huggingface.co, p
 docker run -d -p 3000:8080 -e HF_ENDPOINT=https://hf-mirror.com/ --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
 ```
 
+If you're using Podman on MacOS, to reach Ollama running on your computer you must enable the host loopback with `--network slirp4netns:allow_host_loopback=true` and override `OLLAMA_BASE_URL` to `http://host.containers.internal:11434`. The Open WebUI link remains the default: `http://localhost:3000`.
+
+**Example Podman Command**:
+
+```bash
+podman run -d --network slirp4netns:allow_host_loopback=true -p 3000:8080 -e OLLAMA_BASE_URL=http://host.containers.internal:11434 -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
+```
+
 ### General Connection Errors
 
 **Ensure Ollama Version is Up-to-Date**: Always start by checking that you have the latest version of Ollama. Visit [Ollama's official site](https://ollama.com/) for the latest updates.


### PR DESCRIPTION
Moved from [https://github.com/open-webui/open-webui/pull/1640](https://github.com/open-webui/open-webui/pull/1640), thanks @tjbck for the heads up.

## Description

This pull request adds a section to `TROUBLESHOOTING.md` to assist MacOS users in configuring Podman to communicate with Ollama. This addition fills a gap in our current documentation and provides clear instructions for MacOS users on how to set up their environment.