### PR TITLE
docs: adding reference to serply api for web search

### DIFF
--- a/docs/features.mdx
+++ b/docs/features.mdx
@@ -23,7 +23,7 @@ import { TopBanners } from "@site/src/components/TopBanners";
 
 - 📚 **Local and Remote RAG Integration**: Dive into the future of chat interactions with groundbreaking Retrieval Augmented Generation (RAG) with document interactions in your chat. Load documents or add files to your library, then access them using `#` before a query, or start your prompt with `#`, followed by a URL for web content integration. 
 
-- 🔍 **Web Search for RAG**: Perform web searches using providers like `SearXNG`, `Google PSE`, `Brave Search`, `serpstack`, and `serper`, and inject the results directly into your local Retrieval Augmented Generation (RAG) experience.
+- 🔍 **Web Search for RAG**: Perform web searches using providers like `SearXNG`, `Google PSE`, `Brave Search`, `serpstack`, `serper`, and [`serply`](https://serply.io) and inject the results directly into your local Retrieval Augmented Generation (RAG) experience.
 
 - 🌐 **Web Browsing Capability**: Seamlessly integrate websites into your chat experience using the `#` command followed by a URL. This feature allows you to incorporate web content directly into your conversations, enhancing the richness and depth of your interactions.
 

--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -399,6 +399,10 @@ Query: [query]
 
 - Description: The API key for the Serper search API.
 
+#### `SERPLY_API_KEY`
+
+- Description: The API key for the Serply search API.
+
 #### `RAG_WEB_SEARCH_RESULT_COUNT`
 
 - Default: `3`

--- a/docs/tutorial/web_search.md
+++ b/docs/tutorial/web_search.md
@@ -159,3 +159,5 @@ Navigate to **Workspace > Documents > Document Settings > Web Params**:
 ## Serpstack API
 
 ## Brave API
+
+## Serply API


### PR DESCRIPTION
This to update the docs to reference the Serply Web Search API key: related to https://github.com/open-webui/open-webui/pull/2964