### PR TITLE
Update(README.md): use npm ci instead of npm i.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ## Installation
 
 ```sh
-npm i
+npm ci
 ```
 
 ## Local Development


### PR DESCRIPTION
The command `npm ci` is preferred over `npm i` when there is a `package-lock.json` file because it ensures a consistent and reproducible installation of dependencies.

In contrast, `npm i (or npm install)` installs dependencies based on the `package.json` file and updates the `package-lock.json` file accordingly. If there are conflicts between the two files, `npm i` may introduce changes that you didn't intend to make.