### PR TITLE
fixed mismatched header size (3 to 4) for ENABLE_LOGIN_FORM

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -60,7 +60,7 @@ Here is a list of supported environment variables used by `backend/config.py` in
 - Default: `True`
 - Description: Toggles user account creation.
 
-### `ENABLE_LOGIN_FORM`
+#### `ENABLE_LOGIN_FORM`
 
 - Default: `True`
 - Description: Toggles email, password, sign in and "or" (only when `ENABLE_OAUTH_SIGNUP` is set to true) elements.


### PR DESCRIPTION
In coloration with #156 the new environment variable had the wrong size heading. This simple PR fixes that making it the same size as all other environment variables.