### PR TITLE
Fix TTS environment variable documentation

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -572,22 +572,29 @@ Query: [query]
 
 ### Text to Speech
 
-#### `AUDIO_OPENAI_API_BASE_URL`
+#### `AUDIO_TTS_ENGINE`
+
+- Options:
+  - `` - empty for Web API
+  - `openai` - OpenAI-compatible transcription
+- Description: Specifies the Text-to-Speech engine to use.
+
+#### `AUDIO_TTS_OPENAI_API_BASE_URL`
 
 - Default: `${OPENAI_API_BASE_URL}`
 - Description: Sets the OpenAI-compatible base URL to use for text-to-speech.
 
-#### `AUDIO_OPENAI_API_KEY`
+#### `AUDIO_TTS_OPENAI_API_KEY`
 
 - Default: `${OPENAI_API_KEY}`
 - Description: Sets the API key to use for text-to-speech.
 
-#### `AUDIO_OPENAI_API_MODEL`
+#### `AUDIO_TTS_MODEL`
 
 - Default: `tts-1`
 - Description: Specifies the OpenAI text-to-speech model to use.
 
-#### `AUDIO_OPENAI_API_VOICE`
+#### `AUDIO_TTS_VOICE`
 
 - Default: `alloy`
 - Description: Sets the OpenAI text-to-speech voice to use.

--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -576,7 +576,7 @@ Query: [query]
 
 - Options:
   - `` - empty for Web API
-  - `openai` - OpenAI-compatible transcription
+  - `openai` - OpenAI-compatible text-to-speech.
 - Description: Specifies the Text-to-Speech engine to use.
 
 #### `AUDIO_TTS_OPENAI_API_BASE_URL`


### PR DESCRIPTION
A recent refactor [55dc6c1](https://github.com/open-webui/open-webui/pull/2921/commits/55dc6c1b3be1ef611d96b95e2b940a2dfe7c926d) changed the environment variable names for STT and TTS configuration. This corrects the naming of those variables, and adds the missing AUDIO_TTS_ENGINE option.