### PR TITLE
docs: mention ways to bypass HTTPS restrictions on chromium + untested ways on firefox

### DIFF
--- a/docs/features.mdx
+++ b/docs/features.mdx
@@ -203,7 +203,7 @@ import { TopBanners } from "@site/src/components/TopBanners";
 ### 🎙️ Voice & Accessibility
 
 - 🗣️ **Voice Input Support**: Engage with your model through voice interactions; enjoy the convenience of talking to your model directly. Additionally, explore the option for sending voice input automatically after 3 seconds of silence for a streamlined experience.
-  - Microphone access requires a secure connection over HTTPS for this feature to work.
+  - Microphone access requires manually setting up a secure connection over HTTPS to work, or [manually whitelisting your URL at your own risk](https://docs.openwebui.com/troubleshooting/microphone-access-and-other-permission-issues-with-non-https-connections).
 
 - 😊 **Emoji Call**: Toggle this feature on from the `Settings` > `Interface` menu, allowing LLMs to express emotions using emojis during voice calls for a more dynamic interaction.
   - Microphone access requires a secure connection over HTTPS for this feature to work.

--- a/docs/troubleshooting/index.mdx
+++ b/docs/troubleshooting/index.mdx
@@ -31,6 +31,13 @@ If you're using Podman on MacOS, to reach Ollama running on your computer you mu
 podman run -d --network slirp4netns:allow_host_loopback=true -p 3000:8080 -e OLLAMA_BASE_URL=http://host.containers.internal:11434 -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
 ```
 
+## Microphone access and other permission issues with non-HTTPS connections
+Chromium-based (Chrome, Brave, MS Edge, Opera, Vivaldi,  ...) and firefox-based browsers often restrict site-level permissions on non-HTTPS URLs. This is most obvious when running an instance on your local network and reaching it from another device (example: a phone) of the same network: the microphone permission will most likely get denied right away without a clear way to whitelist the URL. Solutions for this include manually setting up HTTPS or adding an exception to the URL to flag it at secure. Use this at your own risk and we strongly recommend thinking carefully about the security implications before jumping into this.
+
+- To flag a URL as secure on chromium based browsers (Chrome, Brave, MS Edge, Opera, Vivaldi, ...): open `chrome://flags/#unsafely-treat-insecure-origin-as-secure` and add your non HTTPS address (for example: `http://192.168.1.35:3000`) then restart the app.
+
+- On firefox-based browsers: we are not aware of a way to whitelist a URL as easily. You can try clicking on the padlock at the left of the address bar then "Connection is not secure" -> "More information" -> "Permissions" and manually allow the microphone. Alternatively, setting `media.devices.insecure.enabled` to `True` might help.
+
 ## Difficulty Accessing Ollama from Open WebUI
 
 If you're encountering difficulties accessing Ollama from the Open WebUI interface, it could be due to Ollama being configured to listen on a restricted network interface by default. To enable access from the Open WebUI, you need to configure Ollama to listen on a broader range of network interfaces.


### PR DESCRIPTION
As recommended [here](https://github.com/open-webui/open-webui/discussions/4352#discussioncomment-10254871) by @justinh-rahb here's a documentation PR to mention how to whitelist a URL on chromium based browsers to enable microphone support on non HTTPS connections.

I mentioned firefox too but my particular firefox are somewhat modified so I'd appreciate if someone could give it a try.


## Notes:
- A [stackoverflow post](https://stackoverflow.com/questions/66678123/is-there-an-equivalent-of-insecure-origins-treated-as-secure-of-chrome-flag-in) of 2021 mentions that there is no way on firefox to whitelist as easily. It links to [a bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1410365) ticket that is still opened.
- In my specific case on firefox when manually allowing the microphone permission via the padlock and setting `media.devices.insecure.enabled` to `True`, clicking on "Record voice" gets me the following error message: `Permission denied when accessing microphone: NotAllowedError: The request is not allowed by the user agent or the platform in the current context.`. Clicking on "Call" gets me `Permission denied when accessing media devices`.
- This PR is relevant to at least [#1148](https://github.com/open-webui/open-webui/discussions/1148), [#3765](https://github.com/open-webui/open-webui/discussions/3765) and [#4020](https://github.com/open-webui/open-webui/discussions/4020)
