### PR TITLE
Add OAuth Redirect URI env vars

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -722,6 +722,10 @@ Query: [query]
 - Default: `openid email profile`
 - Description: Sets the scope for Google OAuth authentication.
 
+### `GOOGLE_REDIRECT_URI`
+
+- Description: Sets the redirect URI for Google OAuth
+
 #### `MICROSOFT_CLIENT_ID`
 
 - Description: Sets the client ID for Microsoft OAuth
@@ -738,6 +742,10 @@ Query: [query]
 
 - Default: `openid email profile`
 - Description: Sets the scope for Microsoft OAuth authentication.
+
+#### `MICROSOFT_REDIRECT_URI`
+
+- Description: Sets the redirect URI for Microsoft OAuth
 
 #### `OAUTH_CLIENT_ID`
 
@@ -760,6 +768,10 @@ Query: [query]
 
 - Default: `SSO`
 - Description: Sets the name for the OIDC provider.
+
+#### `OPENID_REDIRECT_URI`
+
+- Description: Sets the redirect URI for OIDC
 
 ### LiteLLM
 


### PR DESCRIPTION
I noticed while troubleshooting https://github.com/open-webui/open-webui/discussions/3947 that the `GOOGLE_REDIRECT_URI` / `MICROSOFT_REDIRECT_URI` /  `OPENID_REDIRECT_URI` variables which were [added in v0.3.11](https://github.com/open-webui/open-webui/pull/4262) were not added to the documentation.

This PR adds those definitions to the environment variables page.