### PR TITLE
Crucial Fix: command wrong written, `cp`

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -240,7 +240,7 @@ For Windows:
 git clone https://github.com/open-webui/open-webui.git
 cd open-webui
 
-copy .env.example .env
+cp .env.example .env
 
 npm install
 npm run build


### PR DESCRIPTION
Crucial Fix: command wrong written, `cp`
Some university students and I found this crucial error fix on the guide