### PR TITLE
Update index.mdx

### DIFF
--- a/docs/pipelines/index.mdx
+++ b/docs/pipelines/index.mdx
@@ -93,7 +93,7 @@ That's it! You're now ready to build customizable AI integrations effortlessly w
 
 Get started with Pipelines in a few easy steps:
 
-1. **Ensure Python 3.11 is installed.**
+1. **Ensure Python 3.11 is installed.** It is the only officially supported Python version.
 2. **Clone the Pipelines repository:**
 
    ```sh


### PR DESCRIPTION
Specifies that 3.11 is the only "official" version that's supported. Makes it clearer for the end user in the case that they encounter issues due to their version being something else.

It'll also potentially filter out some other issues from being submitted needlessly.