### PR TITLE
fix: missing v2 in the default sbert model

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -493,7 +493,7 @@ If a function tool doesn't match the query, return an empty string. Else, pick a
 #### `RAG_EMBEDDING_MODEL`
 
 - Type: `str`
-- Default: `sentence-transformers/all-MiniLM-L6`
+- Default: `sentence-transformers/all-MiniLM-L6-v2`
 - Description: Sets a model for embeddings. Locally, a Sentence-Transformer model is used.
 
 #### `RAG_EMBEDDING_MODEL_AUTO_UPDATE`


### PR DESCRIPTION
This was not up to date with this: https://github.com/open-webui/open-webui/blob/e510c8b11f0f898796635cf09aa93a3d72c4c2ee/Dockerfile#L12
