### PR TITLE
fix: docker gpu instructions

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -145,6 +145,8 @@ Visit the [Docker documentation](https://docs.docker.com/storage/) to understand
   docker run -d -p 3000:8080 --gpus all --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:cuda
   ```
 
+  This will result in a faster Bundled Ollama, faster Speech-To-Text and faster RAG embeddings if using SentenceTransformers.
+
 ### Installation for OpenAI API Usage Only
 
 - **If you're only using OpenAI API**, use this command:

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -139,7 +139,7 @@ Visit the [Docker documentation](https://docs.docker.com/storage/) to understand
   docker run -d -p 3000:8080 -e OLLAMA_BASE_URL=https://example.com -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
   ```
 
-  - **To run Open WebUI with Nvidia GPU support**, use this command:
+- **To run Open WebUI with Nvidia GPU support**, use this command:
 
   ```bash
   docker run -d -p 3000:8080 --gpus all --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:cuda


### PR DESCRIPTION
Initially I was mistaken by the indentation and thought it had only to do with ollama. But as I was already running ollama I decided not to enable GPU. I think reminding the user of the STT and embeddings would be better.

- **fix: indentation**
- **docs: add reason for enabling GPU**

