### PR TITLE
wrong description fixed RAG_FILE_MAX_SIZE is MB not Byte

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -713,7 +713,7 @@ Forgery attacks against local network resources.
 #### `RAG_FILE_MAX_SIZE`
 
 - Type: `int`
-- Default: `104857600` (100MB)
+- Default: `100` (100MB)
 - Description: Sets the maximum size of a file that can be uploaded for document ingestion.
 
 ### Web Search


### PR DESCRIPTION
hello,

RAG_FILE_MAX_SIZE was B in the docs but when i set it it acts like MB limit. 
Also, ui is saying it is MB. I tried both cases and find out RAG_FILE_MAX_SIZE defined in .env is MB as well.

So i fixed the wrong document reference. Now it is working correctly.

![image](https://github.com/user-attachments/assets/e9aa48cc-85bb-4104-9c78-51a4a70d2d99)
![image](https://github.com/user-attachments/assets/28093e0d-86ef-42c7-8bc7-4bcc652c0ea4)

Best regards,
Tuna 