### PR TITLE
Documentation: Implementing SwarmUI into Open WebUI

### DIFF
--- a/docs/tutorials/features/images.md
+++ b/docs/tutorials/features/images.md
@@ -104,6 +104,14 @@ Some workflows, such as ones that use any of the Flux models, may utilize multip
 
 After completing these steps, your ComfyUI setup should be integrated with Open WebUI, and you can use the Flux.1 models for image generation.
 
+### Configuring with SwarmUI
+
+SwarmUI utilizes ComfyUI as its backend. In order to get Open WebUI to work with SwarmUI you will have to append `ComfyBackendDirect` to the `ComfyUI Base URL`. Additionally, you will want to setup SwarmUI with LAN access. After aforementioned adjustments, setting up SwarmUI to work with Open WebUI will be the same as [Step one: Configure Open WebUI Settings](https://github.com/open-webui/docs/edit/main/docs/tutorials/features/images.md#step-1-configure-open-webui-settings) as outlined above. 
+![Install SwarmUI with LAN Access](https://github.com/user-attachments/assets/a6567e13-1ced-4743-8d8e-be526207f9f6)
+
+#### SwarmUI API URL
+The address you will input as the ComfyUI Base URL will look like: `http://<your_swarmui_address>:7801/ComfyBackendDirect`
+
 ## OpenAI DALL·E
 
 Open WebUI also supports image generation through the **OpenAI DALL·E APIs**. This option includes a selector for choosing between DALL·E 2 and DALL·E 3, each supporting different image sizes.


### PR DESCRIPTION
- I wrote instructions on how to interface Open WebUI with SwarmUI’s implementation of ComfyUI’s backend.  
- I have tested and everything has been working with Open WebUI for the past week or so now that I was finally able to find the missing link: `ComfyBackendDirect`. This insight was shared with me by the developer of SwarmUI, mcmonkey4eva.  
- SwarmUI’s repo can be found at: https://github.com/mcmonkeyprojects/SwarmUI