### PR TITLE
fix: article should take full width to make use of the empty space

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -431,9 +431,6 @@ article p a {
 	}
 
 	article {
-		max-width: 700px;
-		margin-left: auto;
-		margin-right: auto;
 		padding-top: 20px;
 	}
 }


### PR DESCRIPTION
you can clearly see how much wasted space there is in the first screenshot

the second screenshot shows the default docusaurus max width which is pretty sensible

![image](https://github.com/user-attachments/assets/b6c20a03-8b75-4949-85d8-ad43b2a136e8)

![image](https://github.com/user-attachments/assets/ebde25a7-3a95-412c-9cf8-cdd2dbec18b7)
