### PR TITLE
fix: Move exclude rule to docs section

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -46,12 +46,12 @@ const config: Config = {
 					// Please change this to your repo.
 					// Remove this to remove the "edit this page" links.
 					editUrl: "https://github.com/open-webui/docs/blob/main",
+					exclude: ['**/tab-**/**'],
 				},
 				// blog: false,
 				blog: {
 					showReadingTime: true,
 					// Please change this to your repo.
-					exclude: ['**/tab-**/**'],
 					// Remove this to remove the "edit this page" links.
 					// editUrl:
 					// "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",


### PR DESCRIPTION
This PR corrects the exclude rule placement, moving it from the blog section to the correct docs section.