### PR TITLE
Improve nginx config to support better streaming response from models

### DIFF
--- a/docs/tutorials/integrations/tab-nginx/LetsEncrypt.md
+++ b/docs/tutorials/integrations/tab-nginx/LetsEncrypt.md
@@ -31,6 +31,9 @@ Let's Encrypt provides free SSL certificates trusted by most browsers, ideal for
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            # (Optional) Disable proxy buffering for better streaming response from models
+            proxy_buffering off;
         }
     }
     ```

--- a/docs/tutorials/integrations/tab-nginx/SelfSigned.md
+++ b/docs/tutorials/integrations/tab-nginx/SelfSigned.md
@@ -29,6 +29,9 @@ Using self-signed certificates is suitable for development or internal use where
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            # (Optional) Disable proxy buffering for better streaming response from models
+            proxy_buffering off;
         }
     }
     ```


### PR DESCRIPTION
By default, proxy buffer is turned on in nginx with size of 4KB or 8KB. https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers 

If proxy buffer is turned on, nginx will buffer data received from openwebui and then relay it to user's browser in chunks of 4KB/8KB. This means that when model is returning a streaming response, on browser it is not visible as fluid as it should be. The model response is displayed in chunks and UX is not as beautiful. This only happens if nginx is introduced as a reverse-proxy in between. It does not happen when openwebui is used directly.

This can be easily fixed by turning proxy buffering off. The response received from openwebui is relayed to user's browser immediately, removing the jankiness and restoring the fluid stream of text on browser.