### PR TITLE
Update env-configuration.md

### DIFF
--- a/docs/getting-started/advanced-topics/env-configuration.md
+++ b/docs/getting-started/advanced-topics/env-configuration.md
@@ -1058,6 +1058,12 @@ When enabling `GOOGLE_DRIVE_INTEGRATION`, ensure that you have configured `GOOGL
 - Default: The value of `DATABASE_URL` environment variable
 - Description: Sets the database URL for model storage.
 
+#### `VECTOR_LENGTH`
+
+- Type : int
+- Default : 1536
+- Description : Sets the configurable vector length used for storage operations in the vector database. This was previously hardcoded but is now dynamically read from the environment variable VECTOR_LENGTH. The value must be explicitly set to ensure proper initialization and operation of the vector-related features.
+
 ### Qdrant
 
 #### `QDRANT_API_KEY`


### PR DESCRIPTION
## This is a docs update for https://github.com/open-webui/open-webui/pull/8281

This pull request includes changes to the environment configuration documentation to add a new configuration option for vector length. The most important change is the addition of the `VECTOR_LENGTH` configuration option.

### Configuration Documentation Update:

* [`docs/getting-started/advanced-topics/env-configuration.md`](diffhunk://#diff-d10a9e02a2b9d87144bb5721c9af4362352a65e3ee778a2cab5bf99515a7d915R1061-R1066): Added a new section for `VECTOR_LENGTH` to describe its type, default value, and description. This new option allows the vector length used in storage operations to be dynamically read from the environment variable `VECTOR_LENGTH`, which was previously hardcoded.