### PR TITLE
RAG_FILE_MAX_SIZE units

### DIFF
--- a/docs/getting-started/advanced-topics/env-configuration.md
+++ b/docs/getting-started/advanced-topics/env-configuration.md
@@ -825,7 +825,7 @@ Provide a clear and direct response to the user's query, including inline citati
 #### `RAG_FILE_MAX_SIZE`
 
 - Type: `int`
-- Description: Sets the maximum size of a file that can be uploaded for document ingestion.
+- Description: Sets the maximum size of a file in megabytes that can be uploaded for document ingestion.
 - Persistence: This environment variable is a `PersistentConfig` variable.
 
 #### `RAG_FILE_MAX_COUNT`


### PR DESCRIPTION
Document the units of the environment variable RAG_FILE_MAX_SIZE.
The front end knows the unit [here](https://github.com/open-webui/open-webui/blob/main/src/lib/components/chat/MessageInput.svelte#L227)

