### PR TITLE
Add info about env var DATABASE_SCHEMA

### DIFF
--- a/docs/getting-started/advanced-topics/env-configuration.md
+++ b/docs/getting-started/advanced-topics/env-configuration.md
@@ -1983,6 +1983,16 @@ Documentation on URL scheme available [here](https://docs.sqlalchemy.org/en/20/c
 
 :::
 
+#### `DATABASE_SCHEMA`
+
+- Type: `str`
+- Default: None
+- Description: Specify a schema to use for the database
+
+:::info
+For Postgres, it might be useful to specify the [schema](https://www.postgresql.org/docs/current/ddl-schemas.html) for the tables to avoid conflicts between table names or reserved keywords
+:::
+
 #### `DATABASE_POOL_SIZE`
 
 - Type: `int`


### PR DESCRIPTION
Just adding information about the environment variable DATABASE_SCHEMA that can be used to the schema, when using a postgres database. 

The functionality was included since v.0.5.5. See this PR: https://github.com/open-webui/open-webui/pull/8510