### PR TITLE
Add clarification about the cuda image for docker compose

### DIFF
--- a/docs/getting-started/quick-start/tab-docker/DockerCompose.md
+++ b/docs/getting-started/quick-start/tab-docker/DockerCompose.md
@@ -39,7 +39,7 @@ A useful helper script called `run-compose.sh` is included with the codebase. Th
 
 ---
 
-**Note:** For Nvidia GPU support, add the following to your service definition in the `docker-compose.yml` file:
+**Note:** For Nvidia GPU support, you change the image from `ghcr.io/open-webui/open-webui:main` to `ghcr.io/open-webui/open-webui:cuda` and add the following to your service definition in the `docker-compose.yml` file:
 
 ```yaml
 deploy:


### PR DESCRIPTION
The docs mention that you should use the `:cuda` image when using an NVIDIA GPU on the Docker tab but the same information is missing from the Docker Compose tab. I missed that and spent an hour debugging it.