### PR TITLE
Add citation tool docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.aider*

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-.aider*

--- a/docs/features/plugin/tools/index.mdx
+++ b/docs/features/plugin/tools/index.mdx
@@ -262,7 +262,6 @@ await __event_emitter__(
     }
 )
 ```
-
 If you are sending multiple citations, you can iterate over citations and call the emitter multiple times. When implementing custom citations, ensure that you set `self.citation = False` in your `Tools` class `__init__` method. Otherwise, the built-in citations will override the ones you have pushed in. For example:
 
 ```python
@@ -270,4 +269,44 @@ def __init__(self):
     self.citation = False
 ```
 
-Leaving `self.citation = True` will replace any custom citations you send with automatically generated ones. By disabling it, you can fully manage your own citation references. 
+Leaving `self.citation = True` will replace any custom citations you send with automatically generated ones. By disabling it, you can fully manage your own citation references.
+
+<details>
+<summary>Example</summary>
+
+```
+class Tools:
+    class UserValves(BaseModel):
+        test: bool = Field(
+            default=True, description="test"
+        )
+
+    def __init__(self):
+        self.citation = False
+
+async def test_function(
+        self, prompt: str, __user__: dict, __event_emitter__=None
+    ) -> str:
+        """
+        This is a demo that just creates a citation
+
+        :param test: this is a test parameter
+        """
+
+        await __event_emitter__(
+            {
+                "type": "citation",
+                "data": {
+                    "document": ["This message will be appended to the chat as a citation when clicked into"],
+                    "metadata": [
+                        {
+                            "date_accessed": datetime.now().isoformat(),
+                            "source": title,
+                        }
+                    ],
+                    "source": {"name": "Title of the content"", "url": "http://link-to-citation"},
+                },
+            }
+        )
+```
+</details>

--- a/docs/features/plugin/tools/index.mdx
+++ b/docs/features/plugin/tools/index.mdx
@@ -269,7 +269,7 @@ def __init__(self):
     self.citation = False
 ```
 
-Leaving `self.citation = True` will replace any custom citations you send with automatically generated ones. By disabling it, you can fully manage your own citation references.
+Warning: if you set `self.citation = True`, this will replace any custom citations you send with the automatically generated return citation. By disabling it, you can fully manage your own citation references.
 
 <details>
 <summary>Example</summary>

--- a/docs/features/plugin/tools/index.mdx
+++ b/docs/features/plugin/tools/index.mdx
@@ -6,12 +6,12 @@ title: "⚙️ Tools"
 ## What are Tools?
 Tools are python scripts that are provided to an LLM at the time of the request. Tools allow LLMs to perform actions and receive additional context as a result. Generally speaking, your LLM of choice will need to support function calling for tools to be reliably utilized.
 
-Tools enable many use cases for chats, including web search, web scraping, and API interactions within the chat. 
+Tools enable many use cases for chats, including web search, web scraping, and API interactions within the chat.
 
-Many Tools are available to use on the [Community Website](https://openwebui.com/tools) and can easily be imported into your Open WebUI instance. 
+Many Tools are available to use on the [Community Website](https://openwebui.com/tools) and can easily be imported into your Open WebUI instance.
 
 ## How can I use Tools?
-[Once installed](#how-to-install-tools), Tools can be used by assigning them to any LLM that supports function calling and then enabling that Tool. To assign a Tool to a model, you need to navigate to Workspace => Models. Here you can select the model for which you’d like to enable any Tools. 
+[Once installed](#how-to-install-tools), Tools can be used by assigning them to any LLM that supports function calling and then enabling that Tool. To assign a Tool to a model, you need to navigate to Workspace => Models. Here you can select the model for which you’d like to enable any Tools.
 
 Once you click the pencil icon to edit the model settings, scroll down to the Tools section and check any Tools you wish to enable. Once done you must click save.
 
@@ -241,3 +241,33 @@ async def test_function(
             return f"Tell the user: {e}"
 ```
 </details>
+
+#### Citations
+This type is used to provide citations or references in the chat. You can utilize it to specify the content, the source, and any relevant metadata. Below is an example of how to emit a citation event:
+
+```
+await __event_emitter__(
+    {
+        "type": "citation",
+        "data": {
+            "document": [content],
+            "metadata": [
+                {
+                    "date_accessed": datetime.now().isoformat(),
+                    "source": title,
+                }
+            ],
+            "source": {"name": title, "url": url},
+        },
+    }
+)
+```
+
+If you are sending multiple citations, you can iterate over citations and call the emitter multiple times. When implementing custom citations, ensure that you set `self.citation = False` in your `Tools` class `__init__` method. Otherwise, the built-in citations will override the ones you have pushed in. For example:
+
+```python
+def __init__(self):
+    self.citation = False
+```
+
+Leaving `self.citation = True` will replace any custom citations you send with automatically generated ones. By disabling it, you can fully manage your own citation references. 


### PR DESCRIPTION
Had to reverse engineer the mechanism to send custom citations instead of just the full tool payload as a citation when interacting with a tool, so I thought it might be helpful for others to have in the documentation. This can be used to elegantly display citations, including multiple citations, in a way that the user can easily understand, interact with and follow the link to. 

Before (tool with self.citation = true) - not user friendly and confusing
<img width="571" alt="image" src="https://github.com/user-attachments/assets/2375e195-834d-48d8-afb8-6d99aa8b078e" />

After - individually enumerated, easy to parse responses
<img width="834" alt="image" src="https://github.com/user-attachments/assets/369401f9-2eb8-49f2-adb5-b2f3cc843616" />

