### PR TITLE
Update Kokoro-FastAPI-integration.md

### DIFF
--- a/docs/tutorials/text-to-speech/Kokoro-FastAPI-integration.md
+++ b/docs/tutorials/text-to-speech/Kokoro-FastAPI-integration.md
@@ -111,7 +111,7 @@ To use Kokoro-FastAPI with Open WebUI, follow these steps:
 - Open the Admin Panel and go to `Settings` -> `Audio`
 - Set your TTS Settings to match the following:
 - - Text-to-Speech Engine: OpenAI
-  - API Base URL: `http://localhost:8880/v1`
+  - API Base URL: `http://localhost:8880/v1` # you may need to use `host.docker.internal` instead of `localhost`
   - API Key: `not-needed`
   - TTS Model: `kokoro`
   - TTS Voice: `af_bella` # also accepts mapping of existing OAI voices for compatibility


### PR DESCRIPTION
For my case, using `http://localhost:8880/v1` kept returning Server Connection Errors. Replacing `localhost` to `host.docker.internal` seems to resolve the issue, as I'm running Kokoro-FastAPI in a Docker container.