### PR TITLE
feat: Added description for RAG_WEB_SEARCH_TRUST_ENV in env-configuration.md

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -1151,6 +1151,13 @@ When enabling `GOOGLE_DRIVE_INTEGRATION`, ensure that you have configured `GOOGL
 - Description: Enables or disables search query generation.
 - Persistence: This environment variable is a `PersistentConfig` variable.
 
+#### `RAG_WEB_SEARCH_TRUST_ENV`
+
+- Type: `bool`
+- Default: `False`
+- Description: Enables proxy set by `http_proxy` and `https_proxy` during web search content fetching.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
 #### `RAG_WEB_SEARCH_RESULT_COUNT`
 
 - Type: `int`


### PR DESCRIPTION
Environment variable RAG_WEB_SEARCH_TRUST_ENV was added during web search content fetching update in `0.5.13` (Asynchronous Web Search, [commit `d3f71930f0a129ed7bade3c9cd5c8ed39a67826f`](https://github.com/open-webui/open-webui/commit/d3f71930f0a129ed7bade3c9cd5c8ed39a67826f)). 

Updating to `0.5.13` would make users relying on http proxy for web search before fail to fetch web page content through the proxy designated by `http_proxy` and `https_proxy`. 

Adding this entry to the document would help these users.
  