### PR TITLE
update for redis cache auth and ssl config

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -2173,6 +2173,30 @@ More information about this setting can be found [here](https://docs.sqlalchemy.
 - Default: `redis://localhost:6379/0`
 - Description: Specifies the URL of the Redis instance for websocket communication.
 
+#### `WEBSOCKET_REDIS_CERTS`
+
+- Type: `str`
+- Default: empty string ('')
+- Description: Specifies the path to the Redis SSL certificate for websocket communication.
+
+#### `WEBSOCKET_REDIS_USERNAME`
+
+- Type: `str`
+- Default: empty string ('')
+- Description: Specifies the username for Redis authentication in websocket communication.
+
+#### `WEBSOCKET_REDIS_PASSWORD`
+
+- Type: `str`
+- Default: empty string ('')
+- Description: Specifies the password for Redis authentication in websocket communication.
+
+#### `WEBSOCKET_REDIS_AZURE_CREDENTIALS`
+
+- Type: `bool`
+- Default: `False`
+- Description: Enables the use of Azure credentials for Azure Redis Cache websocket communication. If `WEBSOCKET_REDIS_PASSWORD` is empty DefaultAzureCredentials will be used.
+
 ### Proxy Settings
 
 Open WebUI supports using proxies for HTTP and HTTPS retrievals. To specify proxy settings,

--- a/docs/tutorials/integrations/redis.md
+++ b/docs/tutorials/integrations/redis.md
@@ -104,6 +104,36 @@ docker run -d \
 
 Replace `127.0.0.1` with the actual IP address of your Redis container in the Docker network.
 
+When using SSL connections with Redis, you can set the `WEBSOCKET_REDIS_URL` and `WEBSOCKET_REDIS_CERTS` environment variables as follows:
+
+```bash
+ENABLE_WEBSOCKET_SUPPORT="true"
+WEBSOCKET_MANAGER="redis"
+WEBSOCKET_REDIS_URL="rediss://redis:6379/1"
+WEBSOCKET_REDIS_CERTS="/path/to/redis/certs"
+```
+
+When authenticating with Redis, you can set the `WEBSOCKET_REDIS_USERNAME` and `WEBSOCKET_REDIS_PASSWORD` environment variables as follows:
+
+```bash
+ENABLE_WEBSOCKET_SUPPORT="true"
+WEBSOCKET_MANAGER="redis"
+WEBSOCKET_REDIS_URL="rediss://redis:6379/1"
+WEBSOCKET_REDIS_CERTS="/path/to/redis/certs"
+WEBSOCKET_REDIS_USERNAME="username"
+WEBSOCKET_REDIS_PASSWORD="password"
+```
+
+When using Azure Redis Cache with Open WebUI, you can authenticate with an Azure Managed Identity using DefaultAzureCredentials() by setting the `WEBSOCKET_REDIS_AZURE_CREDENTIALS` environment variable as follows:
+
+```bash
+ENABLE_WEBSOCKET_SUPPORT="true"
+WEBSOCKET_MANAGER="redis"
+WEBSOCKET_REDIS_URL="rediss://redis:6379/1"
+WEBSOCKET_REDIS_CERTS="/path/to/redis/certs"
+WEBSOCKET_REDIS_AZURE_CREDENTIALS="true"
+```
+
 ## Verification
 
 If you have properly set up Redis and configured Open WebUI, you should see the following log message when starting your Open WebUI instance:


### PR DESCRIPTION
Update docs for redis cache auth and SSL configuration options from PR #10581 (https://github.com/open-webui/open-webui/pull/10581)