### PR TITLE
Fix spelling error in sqlite-database.md

### DIFF
--- a/docs/tutorials/tips/sqlite-database.md
+++ b/docs/tutorials/tips/sqlite-database.md
@@ -48,7 +48,7 @@ docker exec -it open-webui /bin/sh
 
 ## Table Overview
 
-Here is a complete list of tables in Open-WebUI's SQLite database. The tables are listed alphabetically and numbered for convinience.
+Here is a complete list of tables in Open-WebUI's SQLite database. The tables are listed alphabetically and numbered for convenience.
 
 | **No.** | **Table Name**   | **Description**                                              |
 | ------- | ---------------- | ------------------------------------------------------------ |


### PR DESCRIPTION
Fixes a small spelling error in `docs/tutorials/tips/sqlite-database.md`: conv**i**nience should be conv**e**nience.