### PR TITLE
fix: double quote

### DIFF
--- a/docs/features/plugin/tools/index.mdx
+++ b/docs/features/plugin/tools/index.mdx
@@ -304,7 +304,7 @@ async def test_function(
                             "source": title,
                         }
                     ],
-                    "source": {"name": "Title of the content"", "url": "http://link-to-citation"},
+                    "source": {"name": "Title of the content", "url": "http://link-to-citation"},
                 },
             }
         )


### PR DESCRIPTION
it is making the example syntactically wrong.

Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>
