### PR TITLE
feat: pip options in tools/functions install requirements

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -2199,3 +2199,17 @@ Open WebUI uses the following environment variables:
 - Description: Lists domain extensions (or IP addresses) for which the proxy should not be used,
 separated by commas. For example, setting no_proxy to '.mit.edu' ensures that the proxy is
 bypassed when accessing documents from MIT.
+
+### Install required packages
+
+Open WebUI provides environment variables to customize the pip installation process. Below are the environment variables used by Open WebUI for adjusting package installation behavior:
+
+#### `PIP_OPTIONS`
+
+- Type: `str`
+- Description: Specifies additional command-line options that pip should use when installing packages. For example, you can include flags such as `--upgrade`, `--user`, or `--no-cache-dir` to control the installation process.
+
+#### `PIP_PACKAGE_INDEX_OPTIONS`
+
+- Type: `str`
+- Description: Defines custom package index behavior for pip. This can include specifying additional or alternate index URLs (e.g., `--extra-index-url`), authentication credentials, or other parameters to manage how packages are retrieved from different locations.


### PR DESCRIPTION
This documentation update provides an overview of the new feature that allows passing optional arguments ([options] & [package-index-options]) to pip install commands within our tools/functions. By doing so, users can specify custom indexes, use proxies, or include additional configuration options during package installation. The instructions herein detail how to integrate these arguments into various workflows and ensure alignment with official pip usage patterns.