### PR TITLE
Handle encoding for json in python example

### DIFF
--- a/docs/getting-started/api-endpoints.md
+++ b/docs/getting-started/api-endpoints.md
@@ -62,7 +62,7 @@ To ensure secure access to the API, authentication is required 🛡️. You can 
           }
         ]
       }
-      response = requests.post(url, headers=headers, data=data)
+      response = requests.post(url, headers=headers, json=data)
       return response.json()
   ```
 


### PR DESCRIPTION
Instead of using data=data, use json=data to ensure the requests library automatically handles the encoding for JSON.

Before this change it has error:

```
{'detail': [{'type': 'json_invalid', 'loc': ['body', 0], 'msg': 'JSON decode error', 'input': {}, 'ctx': {'error': 'Expecting value'}}]}
```