### PR TITLE
Update nginx docs: increase max request size

### DIFF
--- a/docs/tutorials/tab-nginx/LetsEncrypt.md
+++ b/docs/tutorials/tab-nginx/LetsEncrypt.md
@@ -39,6 +39,10 @@ Let's Encrypt provides free SSL certificates trusted by most browsers, ideal for
 
             # (Optional) Disable proxy buffering for better streaming response from models
             proxy_buffering off;
+
+            # (Optional) Increase max request size for large attachments and long audio messages
+            client_max_body_size 20M;
+            proxy_read_timeout 10m;
         }
     }
     ```

--- a/docs/tutorials/tab-nginx/SelfSigned.md
+++ b/docs/tutorials/tab-nginx/SelfSigned.md
@@ -33,6 +33,10 @@ Using self-signed certificates is suitable for development or internal use where
 
             # (Optional) Disable proxy buffering for better streaming response from models
             proxy_buffering off;
+
+            # (Optional) Increase max request size for large attachments and long audio messages
+            client_max_body_size 20M;
+            proxy_read_timeout 10m;
         }
     }
     ```

--- a/docs/tutorials/tab-nginx/Windows.md
+++ b/docs/tutorials/tab-nginx/Windows.md
@@ -129,6 +129,10 @@ http {
 
             # (Optional) Disable proxy buffering for better streaming response from models
             proxy_buffering off;
+
+            # (Optional) Increase max request size for large attachments and long audio messages
+            client_max_body_size 20M;
+            proxy_read_timeout 10m;
         }
     }
 


### PR DESCRIPTION
This PR updates the Nginx configuration example to set `client_max_body_size`, allowing support for large attachments and long audio messages.

The setting is currently applied to `/`, but if needed, it can be moved to specific routes like `/files` and `/transcriptions` to limit its scope. Let me know if any adjustments are required