### PR TITLE
Fix incorrect URL path in documentation

### DIFF
--- a/docs/features/chat-features/url-params.md
+++ b/docs/features/chat-features/url-params.md
@@ -82,7 +82,7 @@ Suppose a user wants to initiate a quick chat session without saving the history
 These URL parameters can be combined to create highly customized chat sessions. For example:
 
 ```bash
-/chat?models=model1,model2&youtube=VIDEO_ID&web-search=true&tools=tool1,tool2&call=true&q=Hello%20there&temporary-chat=true
+/?models=model1,model2&youtube=VIDEO_ID&web-search=true&tools=tool1,tool2&call=true&q=Hello%20there&temporary-chat=true
 ```
 
 This URL will:


### PR DESCRIPTION
This PR addresses a minor error in the documentation where a URL path was incorrectly specified as `/chat?`.

The path has been corrected to `/?` to ensure the link functions as intended and points to the correct page.

**Changes:**

*   Updated the URL path in [mention the specific file or section, e.g., the Getting Started guide] from `/chat?` to `/?`.

This is a small documentation fix.