### PR TITLE
Update continue-dev.md

### DIFF
--- a/docs/tutorials/integrations/continue-dev.md
+++ b/docs/tutorials/integrations/continue-dev.md
@@ -13,11 +13,11 @@ This tutorial is a community contribution and is not supported by the Open WebUI
 
 You can download the VSCode extension here on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Continue.continue)
 
-Once installed you should now have a 'continue' tab in the side bar.
+Once installed you should now have a 'continue' tab in the side bar. Open this.
 
-Open this. Down at the bottom right you should see a settings icon (looks like a cog).
+Click on the Assistant selector above the main chat input. Then hover over "Local Assistant" and you should see a settings icon (looks like a cog).
 
-Once you click on the settings icon a `config.json` should open up in the editor.
+Once you click on the settings icon, a `config.yaml` should open up in the editor.
 
 Here you'll be able to configure continue to use Open WebUI.
 
@@ -33,26 +33,26 @@ We can still setup Continue to use the openai provider which will allow us to us
 
 ## Config
 
-In `config.json` all you will need to do is add/change the following options.
+In `config.yaml` all you will need to do is add/change the following options.
 
 ### Change provider to openai
 
-```json
-"provider": "openai"
+```yaml
+provider: openai
 ```
 
 ### Add or update apiBase
 
 Set this to your Open Web UI domain on the end.
 
-```json
-"apiBase": "http://localhost:3000/" #If you followed Getting Started Docker
+```yaml
+apiBase: http://localhost:3000/ #If you followed Getting Started Docker
 ```
 
 ### Add apiKey
 
-```json
-"apiKey": "sk-79970662256d425eb274fc4563d4525b" # Replace with your API key
+```yaml
+apiKey: sk-79970662256d425eb274fc4563d4525b # Replace with your API key
 ```
 
 You can find and generate your api key from Open WebUI -> Settings -> Account -> API Keys
@@ -61,48 +61,54 @@ You'll want to copy the "API Key" (this starts with sk-)
 
 ## Example Config
 
-Here is a base example of config.json using Open WebUI via an openai provider. Using Granite Code as the model.
+Here is a base example of config.yaml using Open WebUI via an openai provider. Using Granite Code as the model.
 Make sure you pull the model into your ollama instance/s beforehand.
 
-```json
-{
-  "models": [
-    {
-      "title": "Granite Code",
-      "provider": "openai",
-      "model": "granite-code:latest",
-      "useLegacyCompletionsEndpoint": false,
-      "apiBase": "http://YOUROPENWEBUI/ollama/v1",
-      "apiKey": "sk-YOUR-API-KEY"
-    },
-    {
-      "title": "Model ABC from pipeline",
-      "provider": "openai",
-      "model": "PIPELINE_MODEL_ID",
-      "useLegacyCompletionsEndpoint": false,
-      "apiBase": "http://YOUROPENWEBUI/api",
-      "apiKey": "sk-YOUR-API-KEY"
-    }
-  ],
-  "customCommands": [
-    {
-      "name": "test",
-      "prompt": "{{{ input }}}\n\nWrite a comprehensive set of unit tests for the selected code. It should setup, run tests that check for correctness including important edge cases, and teardown. Ensure that the tests are complete and sophisticated. Give the tests just as chat output, don't edit any file.",
-      "description": "Write unit tests for highlighted code"
-    }
-  ],
-  "tabAutocompleteModel": {
-    "title": "Granite Code",
-    "provider": "openai",
-    "model": "granite-code:latest",
-    "useLegacyCompletionsEndpoint": false,
-    "apiBase": "http://localhost:3000/ollama/v1",
-    "apiKey": "sk-YOUR-API-KEY"
-  }
-}
+```yaml
+name: Local Assistant
+version: 1.0.0
+schema: v1
+models:
+  - name: Granite Code
+    provider: openai
+    model: granite-code:latest
+    env:
+      useLegacyCompletionsEndpoint: false
+    apiBase: http://YOUROPENWEBUI/ollama/v1
+    apiKey: sk-YOUR-API-KEY
+    roles:
+      - chat
+      - edit
+
+  - name: Model ABC from pipeline
+    provider: openai
+    model: PIPELINE_MODEL_ID
+    env:
+      useLegacyCompletionsEndpoint: false
+    apiBase: http://YOUROPENWEBUI/api
+    apiKey: sk-YOUR-API-KEY
+    roles:
+      - chat
+      - edit
+
+  - name: Granite Code Autocomplete
+    provider: openai
+    model: granite-code:latest
+    env:
+      useLegacyCompletionsEndpoint: false
+    apiBase: http://localhost:3000/ollama/v1
+    apiKey: sk-YOUR-API-KEY
+    roles:
+      - autocomplete
+
+prompts:
+  - name: test
+    description: Write unit tests for highlighted code
+    prompt: |
+      Write a comprehensive set of unit tests for the selected code. It should setup, run tests that check for correctness including important edge cases, and teardown. Ensure that the tests are complete and sophisticated. Give the tests just as chat output, don't edit any file.
 ```
 
-Save your `config.json` and thats it!
+Save your `config.yaml` and thats it!
 
 You should now see your model in the Continue tab model selection.
 


### PR DESCRIPTION
continue.dev has deprecated json config. A new user installing the continue.dev extension will be presented a yaml config. Update docs to guide the users for setting up the yaml config.
https://docs.continue.dev/reference
![image](https://github.com/user-attachments/assets/4ffb1d35-99c8-4ef4-bb61-ee5e1ac61dcc)
