### PR TITLE
add: Info/Warning for setting up multi-instance setups

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -2238,17 +2238,35 @@ More information about this setting can be found [here](https://docs.sqlalchemy.
 - Default: `False`
 - Description: Enables websocket support in Open WebUI (used with Redis).
 
+:::INFO
+
+When deploying Open-WebUI in a multi-node/worker cluster, you must ensure that the ENABLE_WEBSOCKET_SUPPORT value is set. Without it, websocket consistency and persistency issues will occur.
+
+:::
+
 #### `WEBSOCKET_MANAGER`
 
 - Type: `str`
 - Default: `redis`
 - Description: Specifies the websocket manager to use (in this case, Redis).
 
+:::INFO
+
+When deploying Open-WebUI in a multi-node/worker cluster, you must ensure that the WEBSOCKET_MANAGER value is set and a key-value NoSQL database like Redis is used. Without it, websocket consistency and persistency issues will occur.
+
+:::
+
 #### `WEBSOCKET_REDIS_URL`
 
 - Type: `str`
 - Default: `${REDIS_URL}`
 - Description: Specifies the URL of the Redis instance for websocket communication. It is distinct from `REDIS_URL` and in practice it is recommend to set both.
+
+:::INFO
+
+When deploying Open-WebUI in a multi-node/worker cluster, you must ensure that the WEBSOCKET_REDIS_URL value is set and a key-value NoSQL database like Redis is used. Without it, websocket consistency and persistency issues will occur.
+
+:::
 
 #### `WEBSOCKET_SENTINEL_HOSTS`
 
@@ -2266,6 +2284,12 @@ More information about this setting can be found [here](https://docs.sqlalchemy.
 - Type: `str`
 - Example: `redis://localhost:6379/0`
 - Description: Specifies the URL of the Redis instance for app state.
+
+:::INFO
+
+When deploying Open-WebUI in a multi-node/worker cluster, you must ensure that the REDIS_URL value is set. Without it, session, persistency and consistency issues in the app-state will occur as the workers would be unable to communicate.
+
+:::
 
 #### `REDIS_SENTINEL_HOSTS`
 

--- a/docs/getting-started/quick-start/tab-kubernetes/Helm.md
+++ b/docs/getting-started/quick-start/tab-kubernetes/Helm.md
@@ -29,6 +29,13 @@ Helm helps you manage Kubernetes applications.
    kubectl get pods
    ```
 
+:::warning
+
+If you intend to scale Open WebUI using multiple nodes/pods/workers in a clustered environment, you need to setup a NoSQL key-value database.
+There are some [environment variables](https://docs.openwebui.com/getting-started/env-configuration/) that need to be set to the same value for all service-instances, otherwise consistency problems, faulty sessions and other issues will occur!
+
+:::
+
 ## Access the WebUI
 
 Set up port forwarding or load balancing to access Open WebUI from outside the cluster.

--- a/docs/getting-started/quick-start/tab-kubernetes/Kustomize.md
+++ b/docs/getting-started/quick-start/tab-kubernetes/Kustomize.md
@@ -29,6 +29,13 @@ Kustomize allows you to customize Kubernetes YAML configurations.
    kubectl get pods
    ```
 
+:::warning
+
+If you intend to scale Open WebUI using multiple nodes/pods/workers in a clustered environment, you need to setup a NoSQL key-value database.
+There are some [environment variables](https://docs.openwebui.com/getting-started/env-configuration/) that need to be set to the same value for all service-instances, otherwise consistency problems, faulty sessions and other issues will occur!
+
+:::
+
 ## Access the WebUI
 
 Set up port forwarding or load balancing to access Open WebUI from outside the cluster.


### PR DESCRIPTION
Recently, many users were confused on why their kubernetes setup or multi-worker setup was not functioning properly.

I have decided to try to improve the docs in this regard.

- Adds info blocks to Redis environment variables, notifying the user of the need of setting these environment variables when trying to host Open WebUI in a multi-node/worker/instance environment
- Adds a warning block when choosing the kustomize quick-setup that informs the user to also set up the needed environment variables for scalable setups
- Adds a warning block when choosing the helm quick-setup that informs the user to also set up the needed environment variables for scalable setups

Relates to:
https://github.com/open-webui/open-webui/issues/10365#issuecomment-2784050405

https://github.com/open-webui/open-webui/discussions/9032
https://github.com/open-webui/open-webui/discussions/12362
https://github.com/open-webui/open-webui/issues/12286