### PR TITLE
Update emoji of Workspace index page

### DIFF
--- a/docs/features/workspace/index.mdx
+++ b/docs/features/workspace/index.mdx
@@ -6,8 +6,8 @@ title: "🖥️ Workspace"
 The Workspace in Open WebUI provides a comprehensive environment for managing your AI interactions and configurations. It consists of several key components:
 
 - [🤖 Models](./models.md) - Create and manage custom models tailored to specific purposes
-- [📚 Knowledge](./knowledge.md) - Manage your knowledge bases for retrieval augmented generation
-- [📝 Prompts](./prompts.md) - Create and organize reusable prompts
+- [🧠 Knowledge](./knowledge.md) - Manage your knowledge bases for retrieval augmented generation
+- [📚 Prompts](./prompts.md) - Create and organize reusable prompts
 - [🔒 Permissions](./permissions.md) - Configure access controls and feature availability
 
 Each section of the Workspace is designed to give you fine-grained control over your Open WebUI experience, allowing for customization and optimization of your AI interactions.


### PR DESCRIPTION
The emoji of the Knowledge and Prompts pages at the Workspace index page did not match the ones used on the pages themselves.

![image](https://github.com/user-attachments/assets/65e5bfaa-121e-4770-9456-1fbbd7f94c2f)
