### PR TITLE
Reflect necessary minimum CUDA driver version

### DIFF
--- a/docs/tutorials/text-to-speech/Kokoro-FastAPI-integration.md
+++ b/docs/tutorials/text-to-speech/Kokoro-FastAPI-integration.md
@@ -52,7 +52,7 @@ This tutorial is a community contribution and is not supported by the Open WebUI
 
 ### You can choose between GPU or CPU versions
 
-### GPU Version (Requires NVIDIA GPU with CUDA 12.1)
+### GPU Version (Requires NVIDIA GPU with CUDA 12.8)
 
 Using docker run:
 


### PR DESCRIPTION
When attempting this install on a system with CUDA 12.2, I hit this error:

`nvidia-container-cli: requirement error: unsatisfied condition: cuda>=12.8, please update your driver to a newer version, or use an earlier cuda container: unknown`
