### PR TITLE
Update env-configuration.md with defaults for opensearch

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -1067,6 +1067,7 @@ modeling files for reranking.
 #### `OPENSEARCH_PASSWORD`
 
 - Type: `str`
+- Default: `None`
 - Description: Sets the password for OpenSearch.
 
 #### `OPENSEARCH_SSL`
@@ -1084,6 +1085,7 @@ modeling files for reranking.
 #### `OPENSEARCH_USERNAME`
 
 - Type: `str`
+- Default: `None`
 - Description: Sets the username for OpenSearch.
 
 ### PGVector


### PR DESCRIPTION
added 

- Default: `None`

for opensearch username & password