### PR TITLE
feat: Documentation for WHISPER_LANGUAGE

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -1871,6 +1871,12 @@ Using a remote Playwright browser via `PLAYWRIGHT_WS_URL` can be beneficial for:
 - Default: `False`
 - Description: Toggles automatic update of the Whisper model.
 
+#### `WHISPER_LANGUAGE`
+
+- Type: `str`
+- Default: `None`
+- Description: Specifies the language Whisper uses for TTS. Whisper predicts the language by default. To revert to default behaviour, unset this variable.
+
 ### Speech-to-Text (OpenAI)
 
 #### `AUDIO_STT_ENGINE`

--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -1875,7 +1875,7 @@ Using a remote Playwright browser via `PLAYWRIGHT_WS_URL` can be beneficial for:
 
 - Type: `str`
 - Default: `None`
-- Description: Specifies the language Whisper uses for STT. Whisper predicts the language by default. To revert to default behaviour, unset this variable.
+- Description: Specifies the ISO 639-2 language Whisper uses for STT. Whisper predicts the language by default.
 
 ### Speech-to-Text (OpenAI)
 

--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -1875,7 +1875,7 @@ Using a remote Playwright browser via `PLAYWRIGHT_WS_URL` can be beneficial for:
 
 - Type: `str`
 - Default: `None`
-- Description: Specifies the ISO 639-2 language Whisper uses for STT. Whisper predicts the language by default.
+- Description: Specifies the ISO 639-1 language Whisper uses for STT (ISO 639-2 for Hawaiian and Cantonese). Whisper predicts the language by default.
 
 ### Speech-to-Text (OpenAI)
 

--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -1875,7 +1875,7 @@ Using a remote Playwright browser via `PLAYWRIGHT_WS_URL` can be beneficial for:
 
 - Type: `str`
 - Default: `None`
-- Description: Specifies the language Whisper uses for TTS. Whisper predicts the language by default. To revert to default behaviour, unset this variable.
+- Description: Specifies the language Whisper uses for STT. Whisper predicts the language by default. To revert to default behaviour, unset this variable.
 
 ### Speech-to-Text (OpenAI)
 

--- a/docs/tutorials/speech-to-text/env-variables.md
+++ b/docs/tutorials/speech-to-text/env-variables.md
@@ -19,6 +19,7 @@ The following is a summary of the environment variables for speech to text (STT)
 |----------|-------------|
 | `WHISPER_MODEL` | Sets the Whisper model to use for local Speech-to-Text |
 | `WHISPER_MODEL_DIR` | Specifies the directory to store Whisper model files |
+| `WHISPER_LANGUAGE` | Specifies the Speech-to-Text language to use (language is predicted unless set) |
 | `AUDIO_STT_ENGINE` | Specifies the Speech-to-Text engine to use (empty for local Whisper, or `openai`) |
 | `AUDIO_STT_MODEL` | Specifies the Speech-to-Text model for OpenAI-compatible endpoints |
 | `AUDIO_STT_OPENAI_API_BASE_URL` | Sets the OpenAI-compatible base URL for Speech-to-Text |

--- a/docs/tutorials/speech-to-text/env-variables.md
+++ b/docs/tutorials/speech-to-text/env-variables.md
@@ -19,7 +19,7 @@ The following is a summary of the environment variables for speech to text (STT)
 |----------|-------------|
 | `WHISPER_MODEL` | Sets the Whisper model to use for local Speech-to-Text |
 | `WHISPER_MODEL_DIR` | Specifies the directory to store Whisper model files |
-| `WHISPER_LANGUAGE` | Specifies the Speech-to-Text language to use (language is predicted unless set) |
+| `WHISPER_LANGUAGE` | Specifies the ISO 639-2 Speech-to-Text language to use for Whisper (language is predicted unless set) |
 | `AUDIO_STT_ENGINE` | Specifies the Speech-to-Text engine to use (empty for local Whisper, or `openai`) |
 | `AUDIO_STT_MODEL` | Specifies the Speech-to-Text model for OpenAI-compatible endpoints |
 | `AUDIO_STT_OPENAI_API_BASE_URL` | Sets the OpenAI-compatible base URL for Speech-to-Text |

--- a/docs/tutorials/speech-to-text/env-variables.md
+++ b/docs/tutorials/speech-to-text/env-variables.md
@@ -19,7 +19,7 @@ The following is a summary of the environment variables for speech to text (STT)
 |----------|-------------|
 | `WHISPER_MODEL` | Sets the Whisper model to use for local Speech-to-Text |
 | `WHISPER_MODEL_DIR` | Specifies the directory to store Whisper model files |
-| `WHISPER_LANGUAGE` | Specifies the ISO 639-2 Speech-to-Text language to use for Whisper (language is predicted unless set) |
+| `WHISPER_LANGUAGE` | Specifies the ISO 639-1 (ISO 639-2 for Hawaiian and Cantonese) Speech-to-Text language to use for Whisper (language is predicted unless set) |
 | `AUDIO_STT_ENGINE` | Specifies the Speech-to-Text engine to use (empty for local Whisper, or `openai`) |
 | `AUDIO_STT_MODEL` | Specifies the Speech-to-Text model for OpenAI-compatible endpoints |
 | `AUDIO_STT_OPENAI_API_BASE_URL` | Sets the OpenAI-compatible base URL for Speech-to-Text |


### PR DESCRIPTION
This branch would add documentation changes for the WHISPER_LANGUAGE env variable that was recently added into the main branch (Feature pull request: https://github.com/open-webui/open-webui/pull/13376)

Images below (Note 'ISO 639-2' has since been corrected  to 'ISO 639-1', with an added exception that just Hawaiian and Cantonese use 'ISO 639-2')

/tutorials/speech-to-text/env-variables
![image](https://github.com/user-attachments/assets/e4439181-56d5-4944-9138-2588930ce6ee)

/getting-started/env-configuration
![image](https://github.com/user-attachments/assets/bc510843-577b-4a39-ada4-302a87c561d7)
