### PR TITLE
Update Windows uv installation docs

### DIFF
--- a/docs/getting-started/quick-start/tab-python/Uv.md
+++ b/docs/getting-started/quick-start/tab-python/Uv.md
@@ -25,7 +25,7 @@ Once `uv` is installed, running Open WebUI is a breeze. Use the command below, e
   DATA_DIR=~/.open-webui uvx --python 3.11 open-webui@latest serve
   ```
 
-- **Windows**:  
+- **Windows** (PowerShell):  
   ```powershell
   $env:DATA_DIR="C:\open-webui\data"; uvx --python 3.11 open-webui@latest serve
   ```


### PR DESCRIPTION
The docs contain two commands to run on Windows.  The first command can  be run on any shell; the second is only valid inside PowerShell.  While  the syntax highlighting hints already indicate this, there is no way for the end user to have any knowledge of this; so this commit adds a  notation on the second command denoting it should be run inside  PowerShell