### PR TITLE
Update faq.mdx

### DIFF
--- a/docs/openapi-servers/faq.mdx
+++ b/docs/openapi-servers/faq.mdx
@@ -42,6 +42,7 @@ To work securely in production over HTTPS, your OpenAPI servers must also be ser
 - Go with Swag or Echo
 
 The key is to ensure your server exposes a valid OpenAPI schema, and that it communicates over HTTP(S).
+It is important to set a custom operationId for all endpoints.
 
 ---
 


### PR DESCRIPTION
I added a small but very important point. OperationIds are optional in the openAPI description, but they are required to enable the communication to the tool server. 

When using swagger e.g. with .Net , the operationIds are not set by default, so they need to be added manually.
The current documentation, says, that a standard open api description is supported, but in fact its totally valid to have an endpoint without operationId. 

To ensure others are not running into this issue, i have added it in the documentation :D