### PR TITLE
Enhance env-configuration.md for Qdrant Multitenancy mode 

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -1210,7 +1210,19 @@ modeling files for reranking.
 
 This will disconect all Qdrant collections created in the previous pattern, which is non-multitenancy. Go to  `Admin Settings` > `Documents` > `Reindex Knowledge Base` to migrate existing knowledges.
 
-The Qdrant collections created in the previous pattern will still take resources. Therefore, when you decided to use multitenancy pattern as your default, go to `Admin Settings` > `Documents` to reset Qdrant, which will delete all collections with `open_webui` prefix and then do the Reindex Knowledge Base.
+The Qdrant collections created in the previous pattern will still take resources.
+
+Currently, there is no button on the UI for only reset vector DB, if you want to migrate knowledges to multitenancy:
+- Remove all collections with `open_webui-knowledge` prefix (or `open_webui` prefix to remove all collections related to Open WebUI) with native Qdrant Client
+- Go to  `Admin Settings` > `Documents` > `Reindex Knowledge Base` to migrate existing knowledges
+
+`Reindex Knowledge Base` will ONLY migrate knowledges
+
+:::
+
+:::danger
+
+When you decided to use multitenancy pattern as your default and you don't need to migrate old knowledge, go to `Admin Settings` > `Documents` to reset vector and knowledge, which will delete all collections with `open_webui` prefix and knowledges.
 
 :::
 


### PR DESCRIPTION
I realize the the `Reset Vector Storage/Knowledge` button will both reset Vector Storage and Knowledge information. Therefore, we cannot press `Reset Vector Storage/Knowledge` and perform Knowledge Reindex

This PR provide detailed instructions for migrating to multitenancy in Qdrant. Added steps for removing old collections and clarified the reindexing process for existing knowledge.