### PR TITLE
Update docling.md link to GPU support docker image

### DIFF
--- a/docs/features/document-extraction/docling.md
+++ b/docs/features/document-extraction/docling.md
@@ -29,7 +29,7 @@ docker run -p 5001:5001 -e DOCLING_SERVE_ENABLE_UI=true quay.io/docling-project/
 
 *With GPU support:
 ```bash
-docker run --gpus all -p 5001:5001 -e DOCLING_SERVE_ENABLE_UI=true quay.io/docling-project/docling-serve
+docker run --gpus all -p 5001:5001 -e DOCLING_SERVE_ENABLE_UI=true quay.io/docling-project/docling-serve-cu124
 ```
 
 ### Step 2: Configure Open WebUI to use Docling


### PR DESCRIPTION
Updated link to "*With GPU support:" docker image to include CUDA version (appended '-cu124').