### PR TITLE
Update env-configuration.md

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -490,6 +490,41 @@ JSON format: { "title": "your concise title here" }
 
 - Persistence: This environment variable is a `PersistentConfig` variable.
 
+#### `ENABLE_FOLLOW_UP_GENERATION`
+
+- Type: `bool`
+- Default: `True`
+- Description: Enables or disables tag generation.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `FOLLOW_UP_GENERATION_PROMPT_TEMPLATE`
+
+- Type: `str`
+- Description: Prompt to use for generating several relevant follow-up questions.
+- Default: The value of `DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE` environment variable.
+
+`DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE`:
+
+```
+### Task:
+Suggest 3-5 relevant follow-up questions or prompts that the user might naturally ask next in this conversation as a **user**, based on the chat history, to help continue or deepen the discussion.
+### Guidelines:
+- Write all follow-up questions from the user’s point of view, directed to the assistant.
+- Make questions concise, clear, and directly related to the discussed topic(s).
+- Only suggest follow-ups that make sense given the chat content and do not repeat what was already covered.
+- If the conversation is very short or not specific, suggest more general (but relevant) follow-ups the user might ask.
+- Use the conversation's primary language; default to English if multilingual.
+- Response must be a JSON array of strings, no extra text or formatting.
+### Output:
+JSON format: { "follow_ups": ["Question 1?", "Question 2?", "Question 3?"] }
+### Chat History:
+<chat_history>
+{{MESSAGES:END:6}}
+</chat_history>"
+```
+
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
 #### `TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE`
 
 - Type: `str`


### PR DESCRIPTION
This pull request updates the documentation in `docs/getting-started/env-configuration.md` to include new environment variables related to follow-up question generation. These changes provide detailed descriptions, defaults, and usage guidelines for the new variables.

### Documentation Updates for Environment Variables:

* **`ENABLE_FOLLOW_UP_GENERATION`**: Added a new boolean environment variable that enables or disables follow-up question generation. Default is set to `True`.

* **`FOLLOW_UP_GENERATION_PROMPT_TEMPLATE`**: Introduced a new string environment variable for specifying the prompt template used to generate follow-up questions. Includes a detailed default template with task instructions, guidelines, and JSON output format.