### PR TITLE
Update DockerCompose.md

### DIFF
--- a/docs/getting-started/quick-start/tab-docker/DockerCompose.md
+++ b/docs/getting-started/quick-start/tab-docker/DockerCompose.md
@@ -13,7 +13,6 @@ Docker Compose requires an additional package, `docker-compose-v2`.
 Here is an example configuration file for setting up Open WebUI with Docker Compose:
 
 ```yaml
-version: '3'
 services:
   openwebui:
     image: ghcr.io/open-webui/open-webui:main


### PR DESCRIPTION
Removed "Version" syntax from top of compose file as it is obsolete as of Docker Compose spec v2. See: https://github.com/compose-spec/compose-spec/blob/main/00-overview.md