### PR TITLE
docs: fix JWT_EXPIRES_IN type

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -845,7 +845,7 @@ The value of `API_KEY_ALLOWED_ENDPOINTS` should be a comma-separated list of end
 
 #### `JWT_EXPIRES_IN`
 
-- Type: `int`
+- Type: `str`
 - Default: `-1`
 - Description: Sets the JWT expiration time in seconds. Valid time units: `s`, `m`, `h`, `d`, `w` or `-1` for no expiration.
 - Persistence: This environment variable is a `PersistentConfig` variable.


### PR DESCRIPTION
The type for JWT_EXPIRES_IN is incorrectly labelled as int, however it is a str (due to time units)

https://github.com/open-webui/open-webui/blob/5eca495d3e3b3066e7831141ed2adffbd6d179b4/backend/open_webui/routers/auths.py#L831
