### PR TITLE
docs(quick-start): adding instructions for Podman Kube Play

### DIFF
--- a/docs/getting-started/quick-start/index.mdx
+++ b/docs/getting-started/quick-start/index.mdx
@@ -9,6 +9,7 @@ import { TopBanners } from "@site/src/components/TopBanners";
 
 import DockerCompose from './tab-docker/DockerCompose.md';
 import Podman from './tab-docker/Podman.md';
+import PodmanKubePlay from './tab-docker/PodmanKubePlay.md';
 import ManualDocker from './tab-docker/ManualDocker.md';
 import DockerSwarm from './tab-docker/DockerSwarm.md';
 import DockerUpdating from './tab-docker/DockerUpdating.md';
@@ -58,6 +59,12 @@ Choose your preferred installation method below:
           <Podman />
         </div>
       </TabItem>
+
+    <TabItem value="podman-kube-play" label="Podman Kube Play">
+      <div className='mt-5'>
+        <PodmanKubePlay />
+      </div>
+    </TabItem>
 
       <TabItem value="swarm" label="Docker Swarm">
         <div className='mt-5'>

--- a/docs/getting-started/quick-start/tab-docker/PodmanKubePlay.md
+++ b/docs/getting-started/quick-start/tab-docker/PodmanKubePlay.md
@@ -1,0 +1,69 @@
+# Podman Kube Play Setup
+
+Podman supports Kubernetes like-syntax for deploying resources such as pods, volumes without having the overhead of a full Kubernetes cluster. [More about Kube Play](https://docs.podman.io/en/latest/markdown/podman-kube-play.1.html).
+
+If you don't have Podman installed, check out [Podman's official website](https://podman.io/docs/installation).
+
+## Example `play.yaml`
+
+Here is an example of a Podman Kube Play file to deploy:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: open-webui
+spec:
+  containers:
+    - name: container
+      image: ghcr.io/open-webui/open-webui:main
+      ports:
+        - name: http
+          containerPort: 8080
+          hostPort: 3000
+      volumeMounts:
+        - mountPath: /app/backend/data
+          name: data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName:  open-webui-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: open-webui-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+```
+
+## Starting
+
+To start your pod, run the following command:
+
+```bash
+podman kube play ./play.yaml
+```
+
+## Using GPU Support
+
+For Nvidia GPU support, you need to replace the container image with `ghcr.io/open-webui/open-webui:cuda` and need to specify the device (GPU) required in the pod resources limits as followed:
+
+```yaml
+      [...]
+      resources:
+        limits:
+          nvidia.com/gpu=all: 1
+      [...]
+```
+
+:::important
+
+To successfully have the open-webui container access the GPU(s), 
+you will need to have the Container Device Interface (CDI) for the GPU you wish to access installed in your Podman Machine. You can check [Podman GPU container access](https://podman-desktop.io/docs/podman/gpu).
+
+:::


### PR DESCRIPTION
## Description

I am a [Podman](https://podman.io/) user, and as I usually deploy to my Home-Lab which is pretty low in resources so I don't want to overwhelm with a Kubernetes cluster, so the [Podman Kube Play](https://docs.podman.io/en/latest/markdown/podman-kube-play.1.html) feature is pretty nice!

Therefore while following the quick-start, I quickly converted the compose into Kube Play Yaml as I don't have docker, and I feel like it would be nice to add it to the documentation, next to the other installation method!

As Kube Play has support for GPU access, I try to include the different information.