### PR TITLE
Docs: Warning for bing.md tutorial

### DIFF
--- a/docs/tutorials/web-search/bing.md
+++ b/docs/tutorials/web-search/bing.md
@@ -6,6 +6,9 @@ title: "Bing"
 :::warning
 This tutorial is a community contribution and is not supported by the Open WebUI team. It serves only as a demonstration on how to customize Open WebUI for your specific use case. Want to contribute? Check out the contributing tutorial.
 :::
+:::warning
+Bing Search APIs will be retired on 11th August 2025. New deployments are not supported.
+:::
 
 ## Bing API
 


### PR DESCRIPTION
Adding warning to tutorial page with Bing search because of Bind Search API Deprecation.
> Bing Search APIs will be retired on  August 11, 2025. Any existing instances of Bing Search APIs will be decommissioned completely, and the product will no longer be available for usage or new customer signup. 
> 
> Note that this retirement will apply to partners who are using the F1 and S1 through S9 resources of Bing Search, or the F0 and S1 through S4 resources of Bing Custom Search. 
> 
> Customers may want to consider [Grounding with Bing Search as part of Azure AI Agents](https://aka.ms/AgentsBingDoc).  Grounding with Bing Search allows Azure AI Agents to incorporate real-time public web data when generating responses with an LLM.   
Source: https://azure.microsoft.com/en-us/updates?id=492574
