### PR TITLE
feat: Add support for Redis in Cluster Mode

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -3332,9 +3332,11 @@ More information about this setting can be found [here](https://docs.sqlalchemy.
 #### `REDIS_URL`
 
 - Type: `str`
-- Example: `redis://localhost:6379/0`
-- Example with TLS: `rediss://localhost:6379/0`
-- Description: Specifies the URL of the Redis instance for the app state.
+- Description: Specifies the URL of the Redis instance or cluster host for storing application state.
+- Examples:
+  - `redis://localhost:6379/0`
+  - `rediss://localhost:6379/0` _(with TLS)_
+  - `rediss://:password@redis-cluster.redis.svc.cluster.local:6379/0 ?ssl_cert_reqs=required&ssl_certfile=/tls/redis/tls.crt &ssl_keyfile=/tls/redis/tls.key&ssl_ca_certs=/tls/redis/ca.crt` _(with password and mTLS)_
 
 :::info
 
@@ -3352,6 +3354,18 @@ When deploying Open WebUI in a multi-node/worker cluster with a load balancer, y
 - Type: `int`
 - Default: `26379`
 - Description: Sentinel port for app state Redis.
+
+#### `REDIS_CLUSTER_MODE`
+
+- Type: `bool`
+- Default: `False`
+- Description: Connect to Redis in Cluster Mode instead of to a single instance or using Redis Sentinels. If `True`, `REDIS_URL` must also be defined.
+
+:::info
+
+This option has no effect if `REDIS_SENTINEL_HOSTS` is defined.
+
+:::
 
 #### `REDIS_KEY_PREFIX`
 
@@ -3387,7 +3401,7 @@ When deploying Open WebUI in a multi-node/worker cluster with a load balancer, y
 
 - Type: `str`
 - Default: `${REDIS_URL}`
-- Description: Specifies the URL of the Redis instance for websocket communication. It is distinct from `REDIS_URL` and in practice, it is recommended to set both.
+- Description: Specifies the URL of the Redis instance or cluster host for websocket communication. It is distinct from `REDIS_URL` and in practice, it is recommended to set both.
 
 :::info
 
@@ -3405,6 +3419,18 @@ When deploying Open WebUI in a multi-node/worker cluster with a load balancer, y
 - Type: `int`
 - Default: `26379`
 - Description: Sentinel port for websocket Redis.
+
+#### `WEBSOCKET_REDIS_CLUSTER_MODE`
+
+- Type: `bool`
+- Default: `${REDIS_CLUSTER_MODE}`
+- Description: Specifies that websocket should communicate with Redis in Cluster Mode instead of to a single instance or using Redis Sentinels. If `True`, `WEBSOCKET_REDIS_URL` and/or `REDIS_URL` must also be defined.
+
+:::info
+
+This option has no effect if `WEBSOCKET_SENTINEL_HOSTS` is defined.
+
+:::
 
 ### Uvicorn Settings
 


### PR DESCRIPTION
Updated documentation on Redis related environment variables corresponding to changes in [`open-webui/open-webui` PR #16160](https://github.com/open-webui/open-webui/pull/16160) in order to address [`open-webui/open-webui` issue #16157](https://github.com/open-webui/open-webui/issues/16157):
- `REDIS_URL`
- `REDIS_CLUSTER_MODE` **_NEW_**
- `WEBSOCKET_REDIS_URL`
- `WEBSOCKET_REDIS_CLUSTER_MODE` **_NEW_**