### PR TITLE
Document that disabling admin chat access is often not enough to prevent admins from accessing other users chat

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -152,7 +152,7 @@ is also being used and set to `True`. Failure to do so will result in the inabil
 
 - Type: `bool`
 - Default: `True`
-- Description: Enables admin users to access all chats. When disabled, admins can no longer accesss user's chats in the admin panel.
+- Description: Enables admin users to access all chats. When disabled, admins can no longer access user's chats in the admin panel. If you disable this, you will likely want to also disable `ENABLE_ADMIN_EXPORT`, as the exports also contains user chats.
 
 #### `ENABLE_ADMIN_WORKSPACE_CONTENT_ACCESS`
 


### PR DESCRIPTION
Admin export is available in it's own tab and allows downloading a json file that contains all chats by all users. Not as comfortable as just clicking on that user in the admin interface, but still bad.

This pull request tries to remedy that by highlighting this problem. It is a followup to [open-webui#/16738](https://github.com/open-webui/open-webui/pull/16738).

@Classic298 I would appreciate a review and some guidance on the documentation style you prefer.