### PR TITLE
Fix typo: WEBUI_AUTH_SIGNOUT_REDIRECT_URI -> WEBUI_AUTH_SIGNOUT_REDIR…

### DIFF
--- a/docs/features/sso/index.mdx
+++ b/docs/features/sso/index.mdx
@@ -38,7 +38,7 @@ You cannot have Microsoft **and** Google as providers simultaneously.
 | `OAUTH_MERGE_ACCOUNTS_BY_EMAIL`       | `false`   | Merge OAuth logins based on matching email (⚠️ caution: can be insecure if provider doesn't verify emails).                             |
 | `OAUTH_UPDATE_PICTURE_ON_LOGIN`       | `true`    | Update user profile pictures from OAuth provider with each login.                                                                       |
 | `OAUTH_PICTURE_CLAIM`                 | `picture` | Field in the claim containing the profile picture. Set to empty string to disable picture updates (users receive default icon).         |
-| `WEBUI_AUTH_SIGNOUT_REDIRECT_URI`     | *empty*   | Redirect users to this URL after signout. E.g., `https://your-company.com/logout-success`                                               |
+| `WEBUI_AUTH_SIGNOUT_REDIRECT_URL`     | *empty*   | Redirect users to this URL after signout. E.g., `https://your-company.com/logout-success`                                               |
 
 ### Google
 


### PR DESCRIPTION
WEBUI_AUTH_SIGNOUT_REDIRECT_URI has been renamed to WEBUI_AUTH_SIGNOUT_REDIRECT_URL because the backend expects the latter.