### PR TITLE
Added markdown_header Text Splitter option

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -1718,6 +1718,7 @@ Provide a clear and direct response to the user's query, including inline citati
 - Options:
   - `character`
   - `token`
+  - `markdown_header`
 - Default: `character`
 - Description: Sets the text splitter for RAG models.
 - Persistence: This environment variable is a `PersistentConfig` variable.


### PR DESCRIPTION
This PR adds the option `markdown_header` in the options for `RAG_TEXT_SPLITTER`