### PR TITLE
Document `ENABLE_OTEL_TRACES` configuration

### DIFF
--- a/docs/getting-started/env-configuration.md
+++ b/docs/getting-started/env-configuration.md
@@ -3691,6 +3691,12 @@ If the endpoint is an S3-compatible provider like MinIO that uses a TLS certific
 - Default: `False`
 - Description: Enables or disables OpenTelemetry for observability. When enabled, tracing, metrics, and logging data can be collected and exported to an OTLP endpoint.
 
+#### `ENABLE_OTEL_TRACES`
+
+- Type: `bool`
+- Default: `False`
+- Description: Enables or disables OpenTelemetry traces collection and export. This variable works in conjunction with `ENABLE_OTEL`.
+
 #### `ENABLE_OTEL_METRICS`
 
 - Type: `bool`


### PR DESCRIPTION
Added documentation for the `ENABLE_OTEL_TRACES` environment variable.

Documenting change from https://github.com/open-webui/open-webui/pull/16507 that only enables traces if this environment variable is set to true

Without this set, using OpenWebUI after 0.6.22 disables traces by default whereas prior they were enabled by default with the `ENABLE_OTEL` setting

Would resolve https://github.com/open-webui/open-webui/issues/17667