### PR TITLE
Update env-configuration.mdx

### DIFF
--- a/docs/getting-started/env-configuration.mdx
+++ b/docs/getting-started/env-configuration.mdx
@@ -2157,7 +2157,7 @@ The authentication flow also depends on a browser pop-up window. Please ensure t
 
 - Type: `str`
 - Default: `None`
-- Description: Generic environment variable for the OneDrive Client ID. You should rather use the specific `ONEDRIVE_CLIENT_ID_PERSONAL` or `ONEDRIVE_CLIENT_ID_PERSONAL` variables. This exists as a legacy option for backwards compatibility.
+- Description: Generic environment variable for the OneDrive Client ID. You should rather use the specific `ONEDRIVE_CLIENT_ID_PERSONAL` or `ONEDRIVE_CLIENT_ID_BUSINESS` variables. This exists as a legacy option for backwards compatibility.
 
 #### `ONEDRIVE_CLIENT_ID_PERSONAL`
 


### PR DESCRIPTION
Fixed a minor typo in the description for ONEDRIVE_CLIENT_ID. The earlier description repeated ONEDRIVE_CLIENT_ID_PERSONAL instead of mentioning either business or personal client ID should be used.