### PR TITLE
Initialize Channels documentation with title and sidebar position

### DIFF
--- a/docs/features/channels/index.md
+++ b/docs/features/channels/index.md
@@ -1,1 +1,6 @@
-Soon
+---
+sidebar_position: 7
+title: "📢 Channels"
+---
+
+Soon...


### PR DESCRIPTION
Looks much better. 

Before:
<img width="272" height="165" alt="image" src="https://github.com/user-attachments/assets/c47758e6-7d2c-41d0-ab84-7a04a5600b83" />

After:
<img width="271" height="124" alt="image" src="https://github.com/user-attachments/assets/adc1fa28-a343-4fee-9ebd-dc9250742c60" />
