### PR TITLE
Fix header formatting for MODELS_CACHE_TTL section

### DIFF
--- a/docs/getting-started/env-configuration.mdx
+++ b/docs/getting-started/env-configuration.mdx
@@ -179,7 +179,7 @@ is also being used and set to `True`. Failure to do so will result in the inabil
 - Default: `0`
 - Description: Sets the thread pool size for FastAPI/AnyIO blocking calls. By default (when set to `0`) FastAPI/AnyIO use `40` threads. In case of large instances and many concurrent users, it may be needed to increase `THREAD_POOL_SIZE` to prevent blocking.
 
-### `MODELS_CACHE_TTL`
+#### `MODELS_CACHE_TTL`
 
 - Type: `int`
 - Default: `1`


### PR DESCRIPTION
This makes `MODELS_CACHE_TTL` the same heading level as the other variables. Currently it shows up in the navigation sidebar because it is one level too large.