### PR TITLE
fix: Visually group social icons

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -637,6 +637,10 @@ div.special_table + table tr:nth-child(even) {
 	min-height: 100vh;
 }
 
+.header-discord-link {
+	margin-right: 16px;
+}
+
 .header-github-link::before {
 	content: "";
 	width: 24px;


### PR DESCRIPTION
Visually group social icons together, separate from theme toggle. Previously there was discord icon visually grouped with theme toggle.

Before:
![telegram-cloud-photo-size-2-5465383607314020967-x](https://github.com/user-attachments/assets/9b79fe8d-6319-4634-af82-a69e66cc5f32)

After:
![telegram-cloud-photo-size-2-5465383607314021046-x](https://github.com/user-attachments/assets/608cc007-e633-4600-8ff3-786117400dca)
