### PR TITLE
Removes HOST vars from Trusted Header Docker Compose examples.

### DIFF
--- a/docs/features/auth/sso/index.mdx
+++ b/docs/features/auth/sso/index.mdx
@@ -192,7 +192,7 @@ There are several example configurations that are provided in this page.
 :::danger
 
 Incorrect configuration can allow users to authenticate as any user on your Open WebUI instance.
-Make sure to allow only the authenticating proxy access to Open WebUI, such as setting `HOST=127.0.0.1` to only listen on the loopback interface.
+Make sure to allow only the authenticating proxy access to Open WebUI, such as by not opening any direct ports on the container, or by setting `HOST=127.0.0.1` so that it only listens on the loopback interface.
 
 :::
 
@@ -251,7 +251,6 @@ services:
     volumes:
       - open-webui:/app/backend/data
     environment:
-      - HOST=127.0.0.1
       - WEBUI_AUTH_TRUSTED_EMAIL_HEADER=Tailscale-User-Login
       - WEBUI_AUTH_TRUSTED_NAME_HEADER=Tailscale-User-Name
     restart: unless-stopped
@@ -302,7 +301,6 @@ services:
     volumes:
       - open-webui:/app/backend/data
     environment:
-      - HOST=127.0.0.1
       - WEBUI_AUTH_TRUSTED_EMAIL_HEADER=Cf-Access-Authenticated-User-Email
     restart: unless-stopped
   cloudflared:
@@ -331,7 +329,6 @@ services:
     volumes:
       - open-webui:/app/backend/data
     environment:
-      - 'HOST=127.0.0.1'
       - 'WEBUI_AUTH_TRUSTED_EMAIL_HEADER=X-Forwarded-Email'
       - 'WEBUI_AUTH_TRUSTED_NAME_HEADER=X-Forwarded-User'
     restart: unless-stopped


### PR DESCRIPTION
Fixes #782 