### PR TITLE
feat: Add Docker Desktop Extension to quickstart guide

### DIFF
--- a/docs/getting-started/quick-start/index.mdx
+++ b/docs/getting-started/quick-start/index.mdx
@@ -8,6 +8,7 @@ import TabItem from '@theme/TabItem';
 import { TopBanners } from "@site/src/components/TopBanners";
 
 import DockerCompose from './tab-docker/DockerCompose.md';
+import Extension from './tab-docker/DockerDesktopExtension.md';
 import Podman from './tab-docker/Podman.md';
 import PodmanKubePlay from './tab-docker/PodmanKubePlay.md';
 import ManualDocker from './tab-docker/ManualDocker.md';
@@ -55,19 +56,25 @@ Choose your preferred installation method below:
         </div>
       </TabItem>
 
+      <TabItem value="extension" label="Extension">
+        <div className='mt-5'>
+          <Extension />
+        </div>
+      </TabItem>
+
       <TabItem value="podman" label="Podman">
         <div className='mt-5'>
           <Podman />
         </div>
       </TabItem>
 
-    <TabItem value="podman-kube-play" label="Podman Kube Play">
+    <TabItem value="podman-kube-play" label="Kube Play">
       <div className='mt-5'>
         <PodmanKubePlay />
       </div>
     </TabItem>
 
-      <TabItem value="swarm" label="Docker Swarm">
+      <TabItem value="swarm" label="Swarm">
         <div className='mt-5'>
           <DockerSwarm />
         </div>

--- a/docs/getting-started/quick-start/tab-docker/DockerDesktopExtension.md
+++ b/docs/getting-started/quick-start/tab-docker/DockerDesktopExtension.md
@@ -1,0 +1,6 @@
+# Docker Desktop Extension
+Docker has released an Open WebUI Docker extension that uses Docker Model Runner for inference. You can read their getting started blog here: [Run Local AI with Open WebUI + Docker Model Runner](https://www.docker.com/blog/open-webui-docker-desktop-model-runner/)
+
+You can find troubleshooting steps for the extension in their Github repository: [Open WebUI Docker Extension - Troubleshooting](https://github.com/rw4lll/open-webui-docker-extension?tab=readme-ov-file#troubleshooting)
+
+While this is an amazing resource to try out Open WebUI with little friction, it is not an officially supported installation method - you may run into unexpected bugs or behaviors while using it. For example, you are not able to log in as different users in the extension since it is designed to be for a single local user. If you run into issues using the extension, please submit an issue on the extension's [Github repository](https://github.com/rw4lll/open-webui-docker-extension). 


### PR DESCRIPTION
Adds the [Docker Desktop Extension](https://www.docker.com/blog/open-webui-docker-desktop-model-runner/) as an option in the Quick Start guide. 

The reason other tabs beneath Docker are renamed is because the formatting turns into a mess if we don't: 
<img width="1526" height="268" alt="image" src="https://github.com/user-attachments/assets/813110b7-6be6-45ba-b578-228f298bc4e0" />
