### PR TITLE
docs: Additional (Optional) configuration for external document loader

### DIFF
--- a/docs/getting-started/env-configuration.mdx
+++ b/docs/getting-started/env-configuration.mdx
@@ -1824,6 +1824,83 @@ Note: this configuration assumes that AWS credentials will be available to your 
 - Description: Sets the API key for authenticating with the external document loader service.
 - Persistence: This environment variable is a `PersistentConfig` variable.
 
+#### `EXTERNAL_DOCUMENT_LOADER_HTTP_METHOD`
+
+- Type: `str`
+- Default: `PUT`
+- Description: HTTP method for external document loader requests.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_ENDPOINT`
+
+- Type: `str`
+- Default: `/process`
+- Description: API endpoint path for the external document loader.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_REQUEST_FORMAT`
+
+- Type: `str`
+- Default: `binary`
+- Description: Request format for document uploads. Options: `binary`, `multipart`, `base64`.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_FILE_FIELD_NAME`
+
+- Type: `str`
+- Default: `file`
+- Description: Form field name for the file in multipart requests.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_FILENAME_FIELD_NAME`
+
+- Type: `str`
+- Default: `""`
+- Description: Optional separate form field name for the filename in multipart requests.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_PARAMS`
+
+- Type: `dict`
+- Default: `{}`
+- Description: JSON object for additional request body parameters.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_QUERY_PARAMS`
+
+- Type: `dict`
+- Default: `{}`
+- Description: JSON object for URL query parameters.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_HEADERS`
+
+- Type: `dict`
+- Default: `{}`
+- Description: JSON object for custom HTTP headers.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_RESPONSE_CONTENT_PATH`
+
+- Type: `str`
+- Default: `page_content`
+- Description: JSON path to extract content from the response.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_RESPONSE_METADATA_PATH`
+
+- Type: `str`
+- Default: `metadata`
+- Description: JSON path to extract metadata from the response.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `EXTERNAL_DOCUMENT_LOADER_RESPONSE_TYPE`
+
+- Type: `str`
+- Default: `object`
+- Description: Response format type. Options: `object`, `array`.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
 #### `TIKA_SERVER_URL`
 
 - Type: `str`


### PR DESCRIPTION
Based on feature MR: https://github.com/open-webui/open-webui/pull/19137

To make External Document Engine more powerful for a given generic document processing api, the external document loader can be enabled with default settings (ensuring backwards compatibility), or fully configured with the following settings
- url + api key
- http_method: HTTP method to use (PUT, POST, PATCH)
- endpoint: API endpoint path
- request_format: Format for sending the file (binary, form-data, json-base64)
<details>
<summary>and more advanced settings</summary>

- file_field_name: Name of the file field in form-data or JSON
- filename_field_name: Name of the filename field (optional)
- params: Additional parameters to send with the request
- query_params: Query parameters to append to URL
- custom_headers: Custom headers to include in request
- response_content_path: Dot notation path to content in response
- response_metadata_path: Dot notation path to metadata in response
- response_type: Type of response (object, array, text)
</details>

This optional configuration enables you to point open-webui at almost any document processing api out there, including custom ones. This enables quick and easy testing of open source document projects, or the ability to easily integrate your own custom api with more configuration.