### PR TITLE
docs: Enhance Gemini documentation

### DIFF
--- a/docs/features/image-generation-and-editing/gemini.md
+++ b/docs/features/image-generation-and-editing/gemini.md
@@ -15,7 +15,7 @@ Open WebUI also supports image generation through the **Google AI Studio API** a
 2. You may need to create a project and enable the `Generative Language API` in addition to adding billing information.
 
 :::warning
-If you are utilizing a free API key, it is imperative to have a payment method on file. The absence of a valid payment method is a frequent cause of errors during the setup process.
+If you are utilizing a free API key, it is vital to have a payment method on file. The absence of a valid payment method is a frequent cause of errors during the setup process.
 :::
 
 :::tip


### PR DESCRIPTION
Adds several key clarifications to the Gemini image generation page:
- A warning that a payment method is required for free API keys.
- A tip that a Google Cloud API key from Vertex AI can be used as an alternative to a service account.
- A minimal working setup example to guide users in their configuration.