### PR TITLE
feat: Adds document intelligence model configuration

### DIFF
--- a/docs/getting-started/env-configuration.mdx
+++ b/docs/getting-started/env-configuration.mdx
@@ -2639,6 +2639,13 @@ Strictly return in JSON format:
 - Description: Specifies the key for document intelligence.
 - Persistence: This environment variable is a `PersistentConfig` variable.
 
+#### `DOCUMENT_INTELLIGENCE_MODEL`
+
+- Type: `str`
+- Default: `None`
+- Description: Specifies the model for document intelligence.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
 ### Advanced Settings
 
 #### `BYPASS_EMBEDDING_AND_RETRIEVAL`


### PR DESCRIPTION
Adds the `DOCUMENT_INTELLIGENCE_MODEL` environment variable, allowing users to specify the model used for document intelligence.

Main pull request: https://github.com/open-webui/open-webui/pull/19692