### PR TITLE
Fix TTS settings formatting in documentation

### DIFF
--- a/docs/features/audio/text-to-speech/Kokoro-FastAPI-integration.md
+++ b/docs/features/audio/text-to-speech/Kokoro-FastAPI-integration.md
@@ -117,8 +117,8 @@ To use Kokoro-FastAPI with Open WebUI, follow these steps:
 - - Text-to-Speech Engine: OpenAI
   - API Base URL: `http://localhost:8880/v1` # you may need to use `host.docker.internal` instead of `localhost`
   - API Key: `not-needed`
-  - TTS Model: `kokoro`
   - TTS Voice: `af_bella` # also accepts mapping of existing OAI voices for compatibility
+  - TTS Model: `kokoro`
 
 :::info
 


### PR DESCRIPTION
The documentation has two settings fields reversed when compared to Open WebUI actual settings screen. This causes some people (like me) to input the model in the voice box and the other way around, causing strange errors. By swapping the two fields in the docs, we follow natural order of information (top to bottom, left to right) and make the documentation match the actual settings screen.