### PR TITLE
Fix Typo in DockerCompose.md GPU YAML  

### DIFF
--- a/docs/getting-started/quick-start/tab-docker/DockerCompose.md
+++ b/docs/getting-started/quick-start/tab-docker/DockerCompose.md
@@ -74,7 +74,7 @@ deploy:
     reservations:
       devices:
         - driver: nvidia
-        - count: all
+          count: all
           capabilities: [gpu]
 ```
 


### PR DESCRIPTION
This PR fixes a typo in the code block for Nvidia GPU support. As written the follow error is output with the code:
```
... deploy.resources.reservations.devices.0 missing property 'capabilities'
```
Restoring the code without the hyphen fixes this error.