### PR TITLE
Add missing environment variable name for REDIS_URL

### DIFF
--- a/docs/getting-started/env-configuration.mdx
+++ b/docs/getting-started/env-configuration.mdx
@@ -5617,6 +5617,8 @@ More information about this setting can be found [here](https://docs.sqlalchemy.
 
 ### Redis
 
+#### REDIS_URL
+
 - Type: `str`
 - Description: Specifies the URL of the Redis instance or cluster host for storing application state.
 - Examples:


### PR DESCRIPTION
Add a header with the env var name. I was missing the exact  name of the env var and I think it should be REDIS_URL and it looked.