### PR TITLE
Add missing environment variable name header for REDIS_URL

### DIFF
--- a/docs/getting-started/env-configuration.mdx
+++ b/docs/getting-started/env-configuration.mdx
@@ -5617,6 +5617,8 @@ More information about this setting can be found [here](https://docs.sqlalchemy.
 
 ### Redis
 
+#### REDIS_URL
+
 - Type: `str`
 - Description: Specifies the URL of the Redis instance or cluster host for storing application state.
 - Examples:


### PR DESCRIPTION
I think this is the correct variable name since it's mentioned in many other places in the docs