### PR TITLE
docs: add Vercel AI Gateway to proxies and aggregators list

### DIFF
--- a/docs/getting-started/quick-start/starting-with-openai.mdx
+++ b/docs/getting-started/quick-start/starting-with-openai.mdx
@@ -31,7 +31,7 @@ You can use:
 - **Google Gemini** (via their [OpenAI-compatible endpoint](https://generativelanguage.googleapis.com/v1beta/openai/))
 - **DeepSeek** (https://platform.deepseek.com/)
 - **MiniMax** (https://platform.minimax.io/)
-- **Proxies & Aggregators**: OpenRouter, LiteLLM, Helicone.
+- **Proxies & Aggregators**: OpenRouter, LiteLLM, Helicone, Vercel AI Gateway.
 - **Local Servers**: Ollama, Llama.cpp, LM Studio, vLLM, LocalAI.
 
 ---
@@ -50,7 +50,7 @@ Once Open WebUI is running:
 <Tabs>
   <TabItem value="standard" label="Standard / Compatible" default>
 
-  Use this for **OpenAI**, **DeepSeek**, **MiniMax**, **OpenRouter**, **LocalAI**, **FastChat**, **Helicone**, **LiteLLM**, etc.
+  Use this for **OpenAI**, **DeepSeek**, **MiniMax**, **OpenRouter**, **LocalAI**, **FastChat**, **Helicone**, **LiteLLM**, **Vercel AI Gateway** etc.
 
   *   **Connection Type**: External
   *   **URL**: `https://api.openai.com/v1` (or your provider's endpoint)


### PR DESCRIPTION
### Changes
Add `Vercel AI Gateway` to list of aggregators supported via OpenAI-compatible API.

### Scope
For content that can go live immediately (fixes, tutorials, documentation not dependent on unreleased features)

### Context
[Vercel AI Gateway](https://vercel.com/ai-gateway) is a unified proxy that connects your app to hundreds of AI [models](https://vercel.com/ai-gateway/models) with a single API, offering built-in failover and load balancing for high reliability. It uses a pay-as-you-go model with no price markups.

API connection and key setup guide can be found [here](https://vercel.com/docs/agent-resources/coding-agents). Open WebUI will be added to the list of coding agents in the next couple of days.

Disclaimer: Hi there! I am an employee of Vercel. Please let me know if you have any questions / comments, I will do my best to address them promptly.