### PR TITLE
docs(monitoring): add Opik monitoring integration guide

### DIFF
--- a/docs/tutorials/integrations/monitoring/opik.md
+++ b/docs/tutorials/integrations/monitoring/opik.md
@@ -5,7 +5,7 @@ title: "Opik"
 
 ## Comet Opik Integration with Open WebUI
 
-[Comet Opik](https://www.comet.com/docs/opik/) is an open-source LLM observability and evaluation platform. You can connect Open WebUI telemetry to Opik using OpenTelemetry-compatible pipelines.
+[Comet Opik](https://www.comet.com/site/products/opik/) is an open-source LLM observability and evaluation platform. You can connect Open WebUI telemetry to Opik using OpenTelemetry-compatible pipelines.
 
 ## How to integrate Opik with Open WebUI
 


### PR DESCRIPTION
## Summary
- add an Opik monitoring integration tutorial page for Open WebUI docs
- document OpenTelemetry pipeline configuration pattern for Opik OTLP export
- link to Open WebUI Pipelines and Opik docs

## Test Plan
- docs-only change
- verified frontmatter and markdown structure in `docs/tutorials/integrations/monitoring/opik.md`
