### PR TITLE
custom CA cert: use SSL_CERT_FILE

### DIFF
--- a/docs/tutorials/integrations/custom-ca.md
+++ b/docs/tutorials/integrations/custom-ca.md
@@ -16,9 +16,7 @@ To fix this, you will need to add the new cert into OI's truststore.
 **For pre-built Docker image**:
 
 1. Mount the certificate store from your host machine into the container by passing `--volume=/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro` as a command-line option to `docker run`
-2. Force python to use the system truststore by setting `REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt` (see https://docs.docker.com/reference/cli/docker/container/run/#env)
-
-If the environment variable `REQUESTS_CA_BUNDLE` does not work try to set `SSL_CERT_FILE` (as per the [httpx documentation](https://www.python-httpx.org/environment_variables/#ssl_cert_file)) instead with the same value.
+2. Force python to use the system truststore by setting `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` (see https://docs.docker.com/reference/cli/docker/container/run/#env)
 
 Example `compose.yaml` from [@KizzyCode](https://github.com/open-webui/open-webui/issues/1398#issuecomment-2258463210):
 
@@ -38,7 +36,7 @@ services:
       - WEBUI_SESSION_COOKIE_SAME_SITE=strict
       - WEBUI_SESSION_COOKIE_SECURE=True
       - ENABLE_OLLAMA_API=False
-      - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+      - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ```
 
 The `ro` flag mounts the CA store as read-only and prevents accidental changes to your host CA store


### PR DESCRIPTION
REQUESTS_CA_BUNDLE is proprietary to requests.

SSL_CERT_FILE is part of [PEP 476](https://peps.python.org/pep-0476/#trust-database).

Requests supports SSL_CERT_FILE too: https://github.com/psf/requests/issues/2899