### PR TITLE
docs: Remove duplicate YouTube Loader heading

### DIFF
--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -3820,8 +3820,6 @@ This **timeout only applies when `WEB_LOADER_ENGINE` is set to `safe_web`** or l
 
 ### YouTube Loader
 
-### YouTube Loader
-
 #### `YOUTUBE_LOADER_PROXY_URL`
 
 - Type: `str`


### PR DESCRIPTION
Removed redundant heading for YouTube Loader section.