### PR TITLE
docs: Add missing Default Features step to agentic search setup

### DIFF
--- a/docs/features/chat-conversations/web-search/agentic-search.mdx
+++ b/docs/features/chat-conversations/web-search/agentic-search.mdx
@@ -31,14 +31,15 @@ To unlock these features, your model must support native tool calling and have s
 
 1.  **Enable Web Search Globally**: Ensure a search engine is configured in **Admin Panel → Settings → Web Search**.
 2.  **Enable Model Capability**: In **Admin Panel → Settings → Models**, select your model and enable the **Web Search** capability.
-3.  **Enable Native Mode (Agentic Mode)**:
+3.  **Enable Default Feature**: In the same model settings, under **Default Features**, check **Web Search**. This controls whether the `search_web` and `fetch_url` tools are available by default in new chat sessions.
+4.  **Enable Native Mode (Agentic Mode)**:
     *   In the same model settings, under **Advanced Parameters**, set **Function Calling** to `Native`.
-4.  **Use a Quality Model**: Ensure you're using a frontier model with strong reasoning capabilities for best results.
+5.  **Use a Quality Model**: Ensure you're using a frontier model with strong reasoning capabilities for best results.
 
-:::tip Model Capability vs. Chat Toggle
-In **Native Mode**, the `search_web` and `fetch_url` tools are automatically included based on the model's `web_search` capability setting. The chat toggle is not required.
+:::tip Model Capability, Default Features, and Chat Toggle
+In **Native Mode**, the `search_web` and `fetch_url` tools require both the **Web Search** capability to be enabled *and* **Web Search** to be checked under **Default Features** in the model settings (or toggled on in the chat). If either is missing, the tools will not be injected — even though other builtin tools may still appear.
 
-In **Default Mode** (non-native), the chat toggle still controls whether web search is performed via RAG-style injection.
+In **Default Mode** (non-native), the chat toggle controls whether web search is performed via RAG-style injection.
 
 **Important**: If you disable the `web_search` capability on a model but use Native Mode, the tools won't be available even if you manually toggle Web Search on in the chat.
 :::


### PR DESCRIPTION
## Summary

The [Agentic Search setup guide](https://docs.openwebui.com/features/chat-conversations/web-search/agentic-search/) is missing a required step: enabling **Web Search** under **Default Features** in the model settings.

Without this, the `search_web` and `fetch_url` tools are not injected in Native Mode — even when the Web Search capability and Builtin Tools are both enabled. The model receives other builtin tools (time, memory, notes, etc.) but not the web search tools.

This was confirmed on **v0.8.7** and relates to the behavioral change introduced in [open-webui/open-webui#20641](https://github.com/open-webui/open-webui/issues/20641) (commits `c46ef3b` and `f1a1e64`), which made the per-chat and Default Features toggles functional in Native Mode.

## Changes

- Added **step 3** ("Enable Default Feature") to the setup instructions
- Updated the tip box to clarify that both the Web Search capability *and* the Default Features toggle (or per-chat toggle) control tool injection in Native Mode
- Corrected the previous statement that "The chat toggle is not required" — it is now relevant after the above fix

## Steps to reproduce the original issue

1. Configure Brave (or any provider) in Admin → Settings → Web Search
2. On a model, enable Web Search capability + Builtin Tools
3. Set Function Calling to Native
4. Leave Default Features → Web Search **unchecked**
5. Start a new chat and ask a question requiring current information
6. The model will respond saying it has no web search tools available
7. Enable Default Features → Web Search → the model now calls `search_web` correctly