### PR TITLE
Correct casing of GitHub

### DIFF
--- a/docs/features/access-security/auth/sso/index.mdx
+++ b/docs/features/access-security/auth/sso/index.mdx
@@ -139,15 +139,15 @@ No additional configuration is required in Microsoft Entra ID. The `offline_acce
 
 :::
 
-### Github
+### GitHub
 
-To configure a Github OAuth Client, please refer to [Github's documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps) on how to create a OAuth App or Github App for a **web application**.
+To configure a GitHub OAuth Client, please refer to [GitHub's documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps) on how to create a OAuth App or GitHub App for a **web application**.
 The allowed redirect URI should include `<open-webui>/oauth/github/callback`.
 
 The following environment variables are required:
 
-1. `GITHUB_CLIENT_ID` - Github OAuth App Client ID
-1. `GITHUB_CLIENT_SECRET` - Github OAuth App Client Secret
+1. `GITHUB_CLIENT_ID` - GitHub OAuth App Client ID
+1. `GITHUB_CLIENT_SECRET` - GitHub OAuth App Client Secret
 
 ### OIDC
 


### PR DESCRIPTION
Seeing "Github" instead of "GitHub" was enough to trigger me into opening a pull request to fix it.

https://docs.openwebui.com/features/access-security/auth/sso/