### PR TITLE
docs: add OAUTH_AUTHORIZE_PARAMS env var documentation

### DIFF
--- a/docs/features/access-security/auth/sso/index.mdx
+++ b/docs/features/access-security/auth/sso/index.mdx
@@ -165,6 +165,7 @@ The following environment variables are used:
 1. `OAUTH_SCOPES` - Scopes to request. Defaults to `openid email profile`
 1. `OPENID_REDIRECT_URI` - The redirect URI configured in your OIDC application. This must be set to `<open-webui>/oauth/oidc/callback`.
 1. `OAUTH_AUDIENCE` - Optional `audience` value that will be passed to the oauth provider's authorization endpoint as an additional query parameter.
+1. `OAUTH_AUTHORIZE_PARAMS` - Optional JSON object of extra query parameters to append to the OIDC authorization redirect URL. Useful for OIDC brokers (CILogon, Keycloak, Dex, etc.) that support parameters to pre-select or restrict the upstream identity provider. For example: `{"idphint": "urn:mace:incommon:ucsc.edu"}` for CILogon, `{"kc_idp_hint": "google"}` for Keycloak, or `{"acr_values": "https://refeds.org/profile/mfa"}` to require MFA. Invalid JSON is logged as a warning and ignored.
 
 :::warning
 

--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -5164,6 +5164,30 @@ This is useful when you need a JWT access token for downstream validation or whe
 
 :::
 
+#### `OAUTH_AUTHORIZE_PARAMS`
+
+- Type: `str` (JSON object)
+- Default: Empty string (`''`)
+- Description: A JSON object of extra query parameters to append to the OIDC authorization redirect URL. Its key/value pairs are merged into the kwargs passed to authlib's `authorize_redirect()`, which passes them verbatim to the authorization URL query string. This is useful when using an OIDC broker (such as CILogon, Keycloak, or Dex) that supports parameters to pre-select or restrict the upstream identity provider picker.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+:::info
+
+**Common examples:**
+
+| Broker | Parameter | Example |
+|--------|-----------|---------|
+| CILogon | `idphint` | `{"idphint": "urn:mace:incommon:ucsc.edu"}` |
+| Keycloak | `kc_idp_hint` | `{"kc_idp_hint": "google"}` |
+| Dex | `connector_id` | `{"connector_id": "ldap"}` |
+| Any provider | `acr_values` | `{"acr_values": "https://refeds.org/profile/mfa"}` |
+
+Multiple parameters can be combined in a single JSON object, e.g. `{"idphint": "urn:mace:incommon:ucsc.edu", "skin": "myapp"}`.
+
+Invalid JSON is caught and logged as a warning; non-dict JSON (e.g. an array) is silently ignored. `OAUTH_AUDIENCE` behaviour is not affected.
+
+:::
+
 #### `OAUTH_REFRESH_TOKEN_INCLUDE_SCOPE`
 
 - Type: `bool`


### PR DESCRIPTION
## Summary

- Documents the new `OAUTH_AUTHORIZE_PARAMS` environment variable in the SSO page and env-config reference
- This variable accepts a JSON object of extra query parameters appended to the OIDC authorization redirect URL
- Useful for OIDC brokers (CILogon, Keycloak, Dex) that support parameters to pre-select or restrict the upstream identity provider

## Depends on

This docs PR depends on [open-webui/open-webui#22867](https://github.com/open-webui/open-webui/pull/22867), which adds the feature to the codebase. Marking as draft per the docs contribution guidelines until that PR merges.

## Files changed

- `docs/features/access-security/auth/sso/index.mdx` — added `OAUTH_AUTHORIZE_PARAMS` to the OIDC env var list (item 8, after `OAUTH_AUDIENCE`)
- `docs/reference/env-configuration.mdx` — added full reference entry with type, default, description, and examples table for common brokers