### PR TITLE
docs: clarify TOOL_SERVER_CONNECTIONS schema

### DIFF
--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -1101,7 +1101,15 @@ The format for the JSON response is strictly:
 
 - Type: `str` (JSON array)
 - Default: `[]`
-- Description: Specifies a JSON array of tool server connection configurations. Each connection should define the necessary parameters to connect to external tool servers that implement the OpenAPI/MCPO protocol. The JSON must be properly formatted or it will fallback to an empty array.
+- Description: Specifies a JSON array of tool server connection configurations. Each connection should define the necessary parameters to connect to external tool servers that implement the OpenAPI/MCPO protocol. For mcpo-backed routes, `path` should point at the mounted tool route. The JSON must be properly formatted or it will fallback to an empty array.
+- Field reference:
+  - `url`: the server base URL.
+  - `path`: the specific tool route exposed by the server.
+  - `auth_type`: the authentication mode for the connection.
+  - `key`: the API key or token used by the selected auth mode.
+  - `config`: per-connection configuration object, such as `{ "enable": true }`.
+  - `info`: optional metadata shown in the UI, such as the connection name and description.
+  - `spec_type` / `spec`: OpenAPI spec location details when the connection is backed by a spec URL or file.
 - Example: 
 ```json
 [


### PR DESCRIPTION
Closes #726

This docs-only change clarifies the required `TOOL_SERVER_CONNECTIONS` fields and adds a concise field reference so the sample config is easier to follow.