### PR TITLE
docs: add S3-compatible alternatives section with Tigris example

### DIFF
--- a/docs/getting-started/advanced-topics/scaling.md
+++ b/docs/getting-started/advanced-topics/scaling.md
@@ -220,7 +220,7 @@ Set `STORAGE_PROVIDER` and the corresponding credentials:
 
 | Provider | Set `STORAGE_PROVIDER` to |
 |---|---|
-| Amazon S3 (or S3-compatible like MinIO, R2) | `s3` |
+| Amazon S3 (or S3-compatible like MinIO, R2, Tigris) | `s3` |
 | Google Cloud Storage | `gcs` |
 | Microsoft Azure Blob Storage | `azure` |
 

--- a/docs/tutorials/maintenance/s3-storage.md
+++ b/docs/tutorials/maintenance/s3-storage.md
@@ -100,3 +100,24 @@ Great! Looks like everything is worked as expected in Open-WebUI. Now let's veri
 Using Open-WebUI's swagger docs, we can get all the information related to this file using the `/api/v1/files/{id}` endpoint and passing in the unique ID (4405fabb-603e-4919-972b-2b39d6ad7f5b).
 
 ![Inspect the file by ID](/images/tutorials/amazon-s3/amazon-s3-get-file-by-id.png)
+
+## S3-Compatible Alternatives
+
+The same `s3` storage provider works with any S3-compatible service. Use the same environment variables as above — just swap the endpoint, region, and credentials for your provider.
+
+### Tigris
+
+[Tigris](https://www.tigrisdata.com/) is S3-compatible object storage with zero egress fees and a free tier (5 GB). To use it, set:
+
+| **Variable**         | **Value**                |
+|----------------------|--------------------------|
+| `S3_ENDPOINT_URL`    | `https://t3.storage.dev` |
+| `S3_REGION_NAME`     | `auto`                   |
+
+Create credentials from the [Tigris Dashboard](https://console.tigris.dev/). Keys are prefixed `tid_` / `tsec_`.
+
+:::info
+
+Do not set `S3_ADDRESSING_STYLE` to `path` — Tigris uses virtual-hosted-style addressing, which is the Open WebUI default.
+
+:::


### PR DESCRIPTION
### Summary
Hey! 👋 This PR adds a small subsection to the existing S3 storage tutorial showing how to use S3-compatible providers other than AWS.

- Adds an "S3-Compatible Alternatives" section at the end of `s3-storage.md` explaining that the same s3 storage provider works with any S3-compatible service
- Includes Tigris as the first example — just the two env vars that differ (`S3_ENDPOINT_URL` and `S3_REGION_NAME`), no duplicate docker commands
- Adds "Tigris" to the S3-compatible provider list in `scaling.md` alongside MinIO and R2

The section is structured so other providers (Backblaze B2, Ceph, etc.) can be added below in the same format.

### Why
MinIO's open-source repo was archived in February 2026, and a few users have been asking about alternatives. Tigris is S3-compatible with zero egress fees and a free tier, so it's a natural fit. Rather than a separate tutorial page, this keeps everything in one place and just highlights what's different from the standard AWS setup.