### PR TITLE
docs: replace broken ASCII flowchart with Mermaid for connect-a-provider docs

### DIFF
--- a/docs/getting-started/quick-start/connect-a-provider/index.md
+++ b/docs/getting-started/quick-start/connect-a-provider/index.md
@@ -13,13 +13,16 @@ Open WebUI supports multiple connection protocols, including **Ollama**, **OpenA
 
 ## How It Works
 
-```
-┌──────────────┐         ┌──────────────────┐         ┌──────────────┐
-│              │  HTTP    │                  │  Inference│             │
-│  Open WebUI  │────────▶│  Provider API    │────────▶ │    Model     │
-│  (frontend)  │◀────────│  (cloud/local)   │◀──────── │  (LLM/VLM)  │
-│              │  Stream  │                  │  Tokens  │             │
-└──────────────┘         └──────────────────┘         └──────────────┘
+```mermaid
+flowchart LR
+    A["Open WebUI<br/>(frontend)"]
+    B["Provider API<br/>(cloud / local)"]
+    C["Model<br/>(LLM / VLM)"]
+
+    A -- HTTP --> B
+    B -- Inference --> C
+    C -- Tokens --> B
+    B -- Stream --> A
 ```
 
 1. **You type a message** in Open WebUI


### PR DESCRIPTION
### Summary
Replaced a broken ASCII flowchart in the documentation with an equivalent Mermaid diagram.

- the ASCII diagram was misaligned / hard to read
- improves readability without changing meaning

### Files changed
- docs/getting-started/quick-start/connect-a-provider/index.md
