### PR TITLE
docs: document per-group knowledge base file count and size limits

### DIFF
--- a/docs/features/authentication-access/rbac/permissions.md
+++ b/docs/features/authentication-access/rbac/permissions.md
@@ -46,7 +46,9 @@ Some permissions are **dependent** on others (e.g., you cannot import models if 
 | **Models Access** | **(Parent)** Access the **Models** workspace to create or edit custom models. |
 | **Models Import** | *(Requires Models Access)* Ability to import models from JSON/files. |
 | **Models Export** | *(Requires Models Access)* Ability to export models to files. |
-| **Knowledge Access** | Access the **Knowledge** workspace to manage knowledge bases. |
+| **Knowledge Access** | **(Parent)** Access the **Knowledge** workspace to manage knowledge bases. |
+| **Knowledge Max Files** | *(Requires Knowledge Access)* Maximum number of files allowed per knowledge base. `0` or empty means unlimited. Uses most-permissive merging across groups: if any group grants unlimited, the user has no limit; otherwise the highest value wins. Admins always bypass this limit. |
+| **Knowledge Max File Size** | *(Requires Knowledge Access)* Maximum upload size per file, in MB. `0` or empty means unlimited. Same merging semantics as **Knowledge Max Files**. Admins always bypass this limit. |
 | **Prompts Access** | **(Parent)** Access the **Prompts** workspace to manage custom system prompts. |
 | **Prompts Import** | *(Requires Prompts Access)* Ability to import prompts. |
 | **Prompts Export** | *(Requires Prompts Access)* Ability to export prompts. |

--- a/docs/features/workspace/knowledge.md
+++ b/docs/features/workspace/knowledge.md
@@ -146,6 +146,16 @@ Add dozens of papers to a knowledge base. The AI searches across all of them to 
 
 Files uploaded via API are processed asynchronously. Attempting to use a file before processing completes will fail silently or return empty results.
 
+### Per-group upload limits
+
+Administrators can cap how many files a user may add to a knowledge base and how large each file may be. These limits are configured per group in **Admin Panel > Users > Groups > Permissions > Knowledge Max Files / Knowledge Max File Size**.
+
+- `0` or empty means unlimited.
+- When a user belongs to multiple groups, the most-permissive value wins: if any group grants unlimited, the user has no cap; otherwise the highest limit across groups applies.
+- Admins always bypass both limits.
+
+If a user hits a limit they will see an error before any file processing begins.
+
 ### Native function calling changes behavior
 
 Enabling native function calling changes how knowledge bases work. If your KB suddenly stops producing results, check whether `function_calling: native` was set in global model defaults. See [Knowledge Base troubleshooting](/troubleshooting/rag#13-knowledge-base-attached-to-model-not-working) for details.

--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -5896,6 +5896,20 @@ For API Key creation (and the API keys themselves):
 - Description: Enables or disables user permission to access workspace knowledge.
 - Persistence: This environment variable is a `PersistentConfig` variable.
 
+#### `USER_PERMISSIONS_WORKSPACE_KNOWLEDGE_MAX_COUNT`
+
+- Type: `int`
+- Default: `None` (unlimited)
+- Description: Sets the default maximum number of files allowed per knowledge base for non-admin users. `0` also means unlimited. When a user belongs to multiple groups, the most permissive value wins: if any group grants unlimited (`0` or unset), the user has no cap; otherwise the highest limit across groups applies. Admins always bypass this limit. Can be overridden per group in **Admin Panel → Users → Groups → Permissions → Knowledge Max Files**.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+#### `USER_PERMISSIONS_WORKSPACE_KNOWLEDGE_MAX_SIZE`
+
+- Type: `int`
+- Default: `None` (unlimited)
+- Description: Sets the default maximum file size in MB for knowledge base uploads for non-admin users. `0` also means unlimited. Uses the same most-permissive merging semantics as `USER_PERMISSIONS_WORKSPACE_KNOWLEDGE_MAX_COUNT`. Admins always bypass this limit. Can be overridden per group in **Admin Panel → Users → Groups → Permissions → Knowledge Max File Size**.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
 #### `USER_PERMISSIONS_WORKSPACE_PROMPTS_ACCESS`
 
 - Type: `bool`


### PR DESCRIPTION
Companion documentation for open-webui/open-webui#23992

## Summary

- Added `Knowledge Max Files` and `Knowledge Max File Size` to the Workspace Permissions table in `permissions.md`, including explanation of the 0=unlimited and most-permissive multi-group merging semantics
- Added "Per-group upload limits" subsection to `knowledge.md` under Limitations
- Added `USER_PERMISSIONS_WORKSPACE_KNOWLEDGE_MAX_COUNT` and `USER_PERMISSIONS_WORKSPACE_KNOWLEDGE_MAX_SIZE` to `env-configuration.mdx`

## Files changed

- `docs/features/authentication-access/rbac/permissions.md`
- `docs/features/workspace/knowledge.md`
- `docs/reference/env-configuration.mdx`
