### PR TITLE
Add QuickSilver Pro to OpenAI-compatible providers tab

### DIFF
--- a/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
+++ b/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
@@ -225,6 +225,17 @@ Each connection has a **toggle switch** that lets you enable or disable it witho
   :::
 
   </TabItem>
+  <TabItem value="quicksilverpro" label="QuickSilver Pro">
+
+  **QuickSilver Pro** provides an OpenAI-compatible endpoint for popular open-source models (DeepSeek V3 / R1, Qwen 3.5). Includes a free tier with starter credit so you can test without a credit card.
+
+  | Setting | Value |
+  |---|---|
+  | **URL** | `https://api.quicksilverpro.io/v1` |
+  | **API Key** | Your API key from [quicksilverpro.io](https://quicksilverpro.io/?ref=OWU5N8R3) (email signup, $5 starter credit) |
+  | **Model IDs** | Auto-detected (e.g., `deepseek-v3`, `deepseek-r1`, `qwen3.5-35b`) |
+
+  </TabItem>
   <TabItem value="bedrock" label="Amazon Bedrock">
 
   **Amazon Bedrock** is a fully managed AWS service that provides access to foundation models from leading AI companies (Anthropic, Meta, Mistral, Cohere, Stability AI, Amazon, and more) through a single API.


### PR DESCRIPTION
## What

Adds a tab entry for **QuickSilver Pro** to the OpenAI-compatible Cloud Providers section of `starting-with-openai-compatible.mdx`. Format matches the existing entries for DeepSeek, Mistral, Groq, etc.

## Why

Open WebUI users frequently ask for budget-friendly alternatives for running DeepSeek V3 / R1 / Qwen without self-hosting. QuickSilver Pro is a cloud API for those models with a free-tier starter credit, so readers who land on this page now have one more option to test. `/v1/models` auto-detection works, so no extra admin steps beyond pasting the URL + API key.

## Change

A single `<TabItem>` added to the `<Tabs>` block under **Cloud Providers**. +11 lines, one file touched. No stylistic deviations from existing tabs.

## Testing

- Verified tab renders correctly in local Docusaurus build
- Verified `https://api.quicksilverpro.io/v1/models` responds to `Bearer` auth (401 on invalid key, 200 + model list on valid key) — matches the format expected by Open WebUI's connection verification

## Disclosure

I work on QuickSilver Pro. Happy to strip the `?ref=` query param from the signup link if the maintainers prefer a cleaner URL — flagging proactively. The entry is otherwise factual and mirrors the format of existing providers in the file.

## Checklist

- [x] Atomic — single logical change (one new tab)
- [x] Follows existing conventions (format matches DeepSeek/Mistral/Groq entries)
- [x] No new dependencies
- [x] Docs-only
