### PR TITLE
docs: add FuturMix to OpenAI-compatible providers

### DIFF
--- a/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
+++ b/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
@@ -225,6 +225,17 @@ Each connection has a **toggle switch** that lets you enable or disable it witho
   :::
 
   </TabItem>
+  <TabItem value="futurmix" label="FuturMix">
+
+  **FuturMix** is a unified AI gateway that provides access to 22+ models (Claude, GPT, Gemini, and more) through a single OpenAI-compatible endpoint.
+
+  | Setting | Value |
+  |---|---|
+  | **URL** | `https://futurmix.ai/v1` |
+  | **API Key** | Your API key from [futurmix.ai](https://futurmix.ai) |
+  | **Model IDs** | Auto-detected (e.g., `claude-sonnet-4-20250514`, `gpt-4o`, `gemini-2.5-pro`) |
+
+  </TabItem>
   <TabItem value="bedrock" label="Amazon Bedrock">
 
   **Amazon Bedrock** is a fully managed AWS service that provides access to foundation models from leading AI companies (Anthropic, Meta, Mistral, Cohere, Stability AI, Amazon, and more) through a single API.


### PR DESCRIPTION
## Summary

- Add FuturMix as a cloud provider in the OpenAI-compatible providers documentation
- FuturMix is a enterprise AI agent platform providing access to 22+ models (Claude, GPT, Gemini, and more) 
- Supports `/models` auto-detection — no manual model ID configuration needed

## Details

The new `<TabItem>` follows the same format as existing providers like DeepSeek and Groq (description + settings table with URL, API Key, and auto-detected Model IDs). Placed after OpenRouter in the Cloud Providers tab group.

> Re-submission of #1217, now targeting the `dev` branch per repository contributing guidelines.

## Test plan

- [ ] Verify the MDX renders correctly with no syntax errors
- [ ] Confirm the new tab appears in the Cloud Providers section
- [ ] Verify the table formatting matches other provider tabs