### PR TITLE
fix: correct Feishu OAuth env var names to match code

### DIFF
--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -5309,14 +5309,14 @@ See https://open.feishu.cn/document/sso/web-application-sso/login-overview
 - Description: Sets the client secret for Feishu OAuth.
 - Persistence: This environment variable is a `PersistentConfig` variable.
 
-#### `FEISHU_CLIENT_SCOPE`
+#### `FEISHU_OAUTH_SCOPE`
 
 - Type: `str`
 - Default: `contact:user.base:readonly`
 - Description: Specifies the scope for Feishu OAuth authentication.
 - Persistence: This environment variable is a `PersistentConfig` variable.
 
-#### `FEISHU_CLIENT_REDIRECT_URI`
+#### `FEISHU_REDIRECT_URI`
 
 - Type: `str`
 - Description: Sets the redirect URI for Feishu OAuth.


### PR DESCRIPTION
Fixes open-webui/open-webui#24094

FEISHU_CLIENT_SCOPE → FEISHU_OAUTH_SCOPE
FEISHU_CLIENT_REDIRECT_URI → FEISHU_REDIRECT_URI

Updated docs to match what the code actually reads.