### PR TITLE
docs: fix broken link to contributing tutorial in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This site is built with [Docusaurus](https://docusaurus.io/) and includes:
 
 ## 📝 Contributing
 
-Contributions are welcome! Please read the [contributing guide](docs/tutorials/tips/contributing-tutorial.md) for details.
+Contributions are welcome! Please read the [contributing guide](docs/tutorials/contributing-tutorial.md) for details.
 
 ## 🌐 Live Docs
 


### PR DESCRIPTION
The README pointed to docs/tutorials/tips/contributing-tutorial.md, which 404s. The file lives at docs/tutorials/contributing-tutorial.md.  Removed the extra `tips/` path segment.