### PR TITLE
fix: Remove Watchtower Docs

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -94,7 +94,7 @@ The same principles apply to harsh terrestrial settings: submarines, polar resea
 
 *(Note: If your container or volume has a different name, adjust the commands accordingly.)*
 
-For a deeper dive into update methods (including automated updates like Watchtower), check our full **[Updating Guide](/getting-started/updating)**.
+For a deeper dive into update methods, check our full **[Updating Guide](/getting-started/updating)**.
 
 ### Q: Wait, why would I delete my container? Won't I lose my data?
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -100,12 +100,12 @@ Go beyond the basics. Configure environment variables, connect external database
 
 **Stay current with the latest features and security patches.**
 
-Update manually with a single Docker or pip command, or automate with Watchtower, WUD, or Diun. Includes backup/restore procedures and version pinning for production.
+Update manually with a single Docker or pip command, or set up notifications with WUD or Diun. Includes backup/restore procedures and version pinning for production.
 
 | | |
 | :--- | :--- |
 | 🔄 **Manual update** | Docker pull + recreate, or pip upgrade |
-| 🤖 **Automated updates** | Watchtower, WUD, or Diun |
+| 🤖 **Update notifications** | WUD or Diun |
 | 📌 **Version pinning** | Lock to a specific release for stability |
 | 💾 **Backup & restore** | One-command volume backup and recovery |
 

--- a/docs/getting-started/quick-start/tab-docker/DockerUpdating.md
+++ b/docs/getting-started/quick-start/tab-docker/DockerUpdating.md
@@ -1,18 +1,6 @@
 ## Updating
 
-To update your local Docker installation to the latest version, you can either use **Watchtower** or manually update the container.
-
-### Option 1: Using Watchtower
-
-With [Watchtower](https://github.com/nicholas-fedor/watchtower), you can automate the update process:
-
-```bash
-docker run --rm --volume /var/run/docker.sock:/var/run/docker.sock nickfedor/watchtower --run-once open-webui
-```
-
-*(Replace `open-webui` with your container's name if it's different.)*
-
-### Option 2: Manual Update
+To update your local Docker installation to the latest version, manually update the container:
 
 1. Stop and remove the current container:
 

--- a/docs/getting-started/updating.mdx
+++ b/docs/getting-started/updating.mdx
@@ -185,21 +185,20 @@ If the version you updated to ran a database migration, rolling back the contain
 
 ## Stay Notified About Updates
 
-Instead of checking manually, use a tool to monitor for new releases. Options are listed from safest to most hands-on.
+Instead of checking manually, use a tool to monitor for new releases.
 
 :::tip Recommendation
 - **Production / critical systems:** Diun (notification-only) + manual updates
 - **Managed environments:** WUD (visual dashboard + manual trigger)
-- **Homelabs / personal use:** Watchtower (fully automated)
 :::
 
-| Feature | Diun | WUD | Watchtower |
-|---------|:---:|:---:|:---:|
-| **Auto-updates containers** | ❌ | ❌ (manual via UI) | ✅ |
-| **Web interface** | ❌ | ✅ | ❌ |
-| **Notifications** | ✅ | ✅ | ✅ |
-| **Docker 29+** | ✅ | ✅ | ✅ (forks) |
-| **Resource usage** | Very Low | Medium | Low |
+| Feature | Diun | WUD |
+|---------|:---:|:---:|
+| **Auto-updates containers** | ❌ | ❌ (manual via UI) |
+| **Web interface** | ❌ | ✅ |
+| **Notifications** | ✅ | ✅ |
+| **Docker 29+** | ✅ | ✅ |
+| **Resource usage** | Very Low | Medium |
 
 ### Diun
 
@@ -233,34 +232,6 @@ See [Diun documentation](https://crazymax.dev/diun/) for full setup and notifica
 ### What's Up Docker (WUD)
 
 Web UI for monitoring container updates and triggering them manually. See [WUD documentation](https://getwud.github.io/wud/) for setup.
-
-### Watchtower
-
-Fully automated. Pulls new images and recreates containers without intervention.
-
-:::warning
-The original `containrrr/watchtower` is **no longer maintained** and fails with Docker 29+. Use the [nicholas-fedor/watchtower](https://watchtower.nickfedor.com/) fork instead.
-:::
-
-:::warning
-Automated updates can break your deployment if a release includes breaking changes or database migrations. Review release notes before auto-updating production systems, and always have a backup.
-:::
-
-**One-time update:**
-```bash
-docker run --rm \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  nickfedor/watchtower --run-once open-webui
-```
-
-**Continuous (check every 6 hours):**
-```bash
-docker run -d --name watchtower --restart unless-stopped \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  nickfedor/watchtower --interval 21600 open-webui
-```
-
-Set `WATCHTOWER_CLEANUP=true` to auto-remove old images. See [Watchtower docs](https://watchtower.nickfedor.com/) for scheduling, notifications, and monitor-only mode.
 
 ---
 


### PR DESCRIPTION
Since Watchtower is no longer supported or available, we should clean up the docs because they still reference it as the preferred approach. 