### PR TITLE
docs: admin.analytics permission for analytics-only access

### DIFF
--- a/docs/features/administration/analytics/index.mdx
+++ b/docs/features/administration/analytics/index.mdx
@@ -7,8 +7,10 @@ title: "Analytics"
 
 The **Analytics** feature in Open WebUI provides administrators with comprehensive insights into usage patterns, token consumption, and model performance across their instance. This powerful tool helps you understand how your users are interacting with AI models and make data-driven decisions about resource allocation and model selection.
 
-:::info Admin-Only Feature
-Analytics is only accessible to users with **admin** role. Access it via **Admin Panel > Analytics**.
+:::info Who Can Access Analytics
+Full **admin** users always have access via **Admin Panel > Analytics**.
+
+Users with the regular **user** role can also access Analytics when granted the **`admin.analytics`** permission (see [Permissions — Admin Permissions](/features/authentication-access/rbac/permissions#6-admin-permissions)). Those users see **Analytics** in the profile menu instead of the full Admin Panel and only the Analytics tab in the admin area.
 :::
 
 :::tip Disabling Analytics
@@ -32,9 +34,27 @@ All analytics data is derived from the message history stored in your instance's
 
 ## Accessing Analytics
 
+### Administrators
+
 1. Log in with an **admin** account
-2. Navigate to **Admin Panel** (click your profile icon → Admin Panel)
-3. Click on the **Analytics** tab in the admin navigation
+2. Navigate to **Admin Panel** (profile menu → **Admin Panel**)
+3. Open the **Analytics** tab
+
+### Analytics-only users
+
+1. Log in with a **user** account that has **`admin.analytics`** enabled
+2. Open the profile menu and choose **Analytics**
+3. You are taken directly to the Analytics dashboard (other admin tabs are not shown)
+
+### Granting analytics access
+
+| Scope | Where to configure |
+| :--- | :--- |
+| **All new users (default)** | **Admin Panel → Users → Groups → Default Permissions** → **Admin Permissions → Analytics Access** |
+| **A group** | Edit the group → **Permissions** → **Admin Permissions → Analytics Access** |
+| **One user** | **Admin Panel → Users** → edit user → **Analytics Access** toggle |
+
+Permissions are **additive**: access is granted if the global default, **any** group, or the user's individual override enables it. See [Permissions](/features/authentication-access/rbac/permissions) for details.
 
 ---
 

--- a/docs/features/authentication-access/rbac/permissions.md
+++ b/docs/features/authentication-access/rbac/permissions.md
@@ -35,7 +35,7 @@ This approach ensures that new users don't accidentally get access to sensitive 
 
 ## Permission Categories
 
-Permissions are organized into five main categories: **Workspace**, **Sharing**, **Chat**, **Features**, and **Settings**.
+Permissions are organized into six main categories: **Workspace**, **Sharing**, **Chat**, **Features**, **Settings**, and **Admin**.
 
 ### 1. Workspace Permissions
 Controls access to the "Workspace" section where users create and manage resources.
@@ -150,6 +150,25 @@ Controls access to user settings areas.
 | Permission | Description |
 | :--- | :--- |
 | **Interface Settings Access** | Ability to access and modify interface settings in user settings. |
+
+### 6. Admin Permissions
+Controls access to admin-panel surfaces without granting full administrator role.
+
+| Permission | Key | Description |
+| :--- | :--- | :--- |
+| **Analytics Access** | `admin.analytics` | Access the **Analytics** dashboard and `/api/v1/analytics/*` endpoints. User sees **Analytics** in the profile menu (not the full Admin Panel) and only the Analytics tab. Other admin areas (Users, Settings, Functions, etc.) remain inaccessible. |
+
+:::info Analytics Permission Scope
+
+For Analytics access:
+
+1. **Feature toggle**: The Analytics API and UI must be enabled via [`ENABLE_ADMIN_ANALYTICS`](/reference/env-configuration#enable_admin_analytics) (default `True`).
+2. **Permission check for non-admins**: Users with the `user` role need **`admin.analytics`** from global defaults, a group, and/or per-user permissions.
+3. **Admins are exempt from `admin.analytics`**: Users with the `admin` role always have analytics access when the feature is enabled.
+
+Default permission can be configured via [`USER_PERMISSIONS_ADMIN_ANALYTICS`](/reference/env-configuration#user_permissions_admin_analytics).
+
+:::
 
 :::info API Keys Permission Scope
 

--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -401,6 +401,12 @@ Treat anything in this cluster as *what the admin sees and does in the product U
 - Default: `True`
 - Description: Controls whether the admin-panel **Analytics** tab is visible and the analytics API router is mounted. When set to `False`, the tab is hidden and the corresponding endpoints are not registered. Disabling does not stop the underlying data being collected, and admin retains the ability to query that data directly from the database — this toggle controls the in-product surface, see the admin-posture-toggles note above. Requires a restart to take effect.
 
+#### `USER_PERMISSIONS_ADMIN_ANALYTICS`
+
+- Type: `bool`
+- Default: `False`
+- Description: Default value for the **`admin.analytics`** RBAC permission applied to all users (combined with group and per-user overrides). When `True`, regular users can open the Analytics dashboard without full admin role, subject to `ENABLE_ADMIN_ANALYTICS`. Administrators always have analytics access when the feature is enabled. Configure per-user via **Admin Panel → Users → Edit user → Analytics Access**, or per-group in group permissions. See [Permissions — Admin Permissions](/features/authentication-access/rbac/permissions#6-admin-permissions).
+
 #### `BYPASS_ADMIN_ACCESS_CONTROL`
 
 - Type: `bool`


### PR DESCRIPTION
## Summary
- Document `admin.analytics` RBAC permission and analytics-only user experience
- Update Analytics feature page, Permissions reference, and env configuration

## Related
- Discussion: https://github.com/open-webui/open-webui/discussions/24862
- open-webui PR: (linked after creation)

## Changes
- [Analytics](/features/administration/analytics): access for non-admin users, granting table
- [Permissions](/features/authentication-access/rbac/permissions): new Admin Permissions section
- [env-configuration](/reference/env-configuration): `USER_PERMISSIONS_ADMIN_ANALYTICS`

Made with [Cursor](https://cursor.com)