### PR TITLE
Update contributing instructions to match GitHub UI

### DIFF
--- a/docs/tutorials/contributing-tutorial.md
+++ b/docs/tutorials/contributing-tutorial.md
@@ -28,7 +28,7 @@ We appreciate your interest in contributing tutorials to the Open WebUI document
 3. **Enable GitHub Pages**
 
    - Go to **Settings** > **Pages** in your forked repository.
-   - Under **Source**, select the branch you want to deploy (e.g., `main`) and the folder (e.g.,`/docs`).
+   - Under **Branch**, select the branch you want to deploy (e.g., `main`) and the folder (e.g.,`/docs`).
    - Click **Save** to enable GitHub Pages.
 
 4. **Configure GitHub Environment Variables**


### PR DESCRIPTION
Changes contributing instructions to match GitHub UI for Build and deployment.

The instructions say:

> 3. **Enable GitHub Pages**
>    - Go to **Settings** > **Pages** in your forked repository.
>    - Under **Source**, select the branch you want to deploy (e.g., `main`) and the folder (e.g.,`/docs`).
>    - Click **Save** to enable GitHub Pages.

but GitHub UI has the branch selection under the "Branch" section instead:

<img width="1014" height="928" alt="A screenshot of the GitHub Pages Build and deployment section showing the branch selection UI." src="https://github.com/user-attachments/assets/59d376da-5db6-43c5-8478-cff683371703" />


So this updates the instructions to match.