### PR TITLE
Remove obsolete docker-compose version lines

### DIFF
--- a/docs/features/authentication-access/auth/ldap.mdx
+++ b/docs/features/authentication-access/auth/ldap.mdx
@@ -12,7 +12,6 @@ This guide provides a comprehensive walkthrough for setting up OpenLDAP authenti
 The easiest way to get a test OpenLDAP server running is by using Docker. This `docker-compose.yml` file will create an OpenLDAP container and an optional phpLDAPadmin container for a web-based GUI.
 
 ```yaml title="docker-compose.yml"
-version: "3.9"
 services:
   ldap:
     image: osixia/openldap:1.5.0

--- a/docs/features/chat-conversations/rag/document-extraction/docling.md
+++ b/docs/features/chat-conversations/rag/document-extraction/docling.md
@@ -42,7 +42,6 @@ docker run --gpus all -p 5001:5001 \
 **Recommended production deployment with Docker Compose:**
 
 ```yaml
-version: "3.8"
 services:
   docling-serve:
     image: quay.io/docling-project/docling-serve-cu128:latest

--- a/docs/getting-started/quick-start/tab-docker/DockerSwarm.md
+++ b/docs/getting-started/quick-start/tab-docker/DockerSwarm.md
@@ -34,8 +34,6 @@ Choose the appropriate command based on your hardware setup:
 #### Docker-stack.yaml
 
     ```yaml
-    version: '3.9'
-
     services:
       openWebUI:
         image: ghcr.io/open-webui/open-webui:main

--- a/docs/tutorials/integrations/dev-tools/jupyter.md
+++ b/docs/tutorials/integrations/dev-tools/jupyter.md
@@ -38,8 +38,6 @@ Here is the target configuration we're going to set-up through this tutorial.
 To accomplish this, I used `docker-compose` to launch a stack that includes both services, along with my LLMs, but this should also work if run each docker container separately.
 
 ```yaml title="docker-compose.yml"
-version: "3.8"
-
 services:
 open-webui:
 image: ghcr.io/open-webui/open-webui:latest

--- a/docs/tutorials/integrations/redis.md
+++ b/docs/tutorials/integrations/redis.md
@@ -140,7 +140,6 @@ With proper `timeout` configuration, this number should fluctuate naturally (ris
 To set up Redis for websocket support, you will need to create a `docker-compose.yml` file with the following contents:
 
 ```yml
-version: '3.9'
 services:
   redis:
     image: docker.io/valkey/valkey:8.0.1-alpine


### PR DESCRIPTION
Remove top-level `version` element from several docker-compose example YAML blocks across documentation. These are obsolete in the Compose Specification (see https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete), removing them avoids promoting deprecated/explicit Compose file versioning and keeps examples compatible with newer Docker Compose semantics.