### PR TITLE
docs: document OAUTH_AUTO_REDIRECT

### DIFF
--- a/docs/features/authentication-access/auth/sso/index.mdx
+++ b/docs/features/authentication-access/auth/sso/index.mdx
@@ -31,6 +31,7 @@ You cannot have Microsoft **and** Google as OIDC providers simultaneously.
 | `WEBUI_URL`                           | —                  | **Required.** Your public WebUI address, e.g., `http://localhost:8080`. |
 | `ENABLE_OAUTH_PERSISTENT_CONFIG`      | `true`             | Persist OAuth config to the database; set to `false` for stateless/containerized environments. |
 | `ENABLE_OAUTH_SIGNUP`                 | `false`            | Allows account creation upon OAuth login (separate from `ENABLE_SIGNUP`). |
+| `OAUTH_AUTO_REDIRECT`                 | `false`            | When `true` and the deployment is SSO-only — exactly one OAuth provider, `ENABLE_LOGIN_FORM=false`, `ENABLE_LDAP=false` — sends unauthenticated users from `/auth` straight to the provider, skipping the "Continue with" screen. Visit `/auth?form=true` to reach the local login form. |
 | `OAUTH_MERGE_ACCOUNTS_BY_EMAIL`       | `false`            | Merge OAuth logins based on matching email (caution: can be insecure if provider doesn't verify emails). |
 | `OAUTH_UPDATE_PICTURE_ON_LOGIN`       | `false`             | Update user profile pictures from OAuth provider with each login. |
 | `OAUTH_PICTURE_CLAIM`                 | `picture`          | Field in the claim containing the profile picture. Set to empty string to disable picture updates (users receive default icon).|

--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -5050,6 +5050,19 @@ You can only configure one OAUTH provider at a time. You cannot have two or more
 
 :::
 
+#### `OAUTH_AUTO_REDIRECT`
+
+- Type: `bool`
+- Default: `False`
+- Description: When `True` and the deployment is configured for SSO-only sign-in — exactly one OAuth provider configured, `ENABLE_LOGIN_FORM=false`, and `ENABLE_LDAP=false` — an unauthenticated visit to the `/auth` page is redirected straight to that provider's login, skipping the intermediate `Continue with <provider>` button. The redirect is suppressed when the local login form is explicitly requested (`/auth?form=true`), after a failed sign-in (`/auth?error=...`), for an already-authenticated session, during initial onboarding, and when trusted-header authentication is enabled. Has no effect when zero or multiple OAuth providers are configured, when the local login form or LDAP is enabled, or when the variable is set in a deployment that doesn't satisfy all of the above.
+- Persistence: This environment variable is a `PersistentConfig` variable.
+
+:::tip
+
+Visit `/auth?form=true` to reach the local login form when `OAUTH_AUTO_REDIRECT` is enabled — useful for administrators who need password access if the OAuth provider is unavailable.
+
+:::
+
 #### `ENABLE_OAUTH_PERSISTENT_CONFIG`
 
 - Type: `bool`


### PR DESCRIPTION
## What

Documents the new `OAUTH_AUTO_REDIRECT` environment variable, added to Open WebUI in a companion code PR (open-webui/open-webui).

When `OAUTH_AUTO_REDIRECT` is enabled and exactly one OAuth provider is configured, an unauthenticated visit to `/auth` is redirected straight to that provider — skipping the intermediate "Continue with &lt;provider&gt;" button. `/auth?form=true` reaches the local login form.

## Changes

- `docs/reference/env-configuration.mdx` — new `OAUTH_AUTO_REDIRECT` entry in the OAuth section (Type / Default / Description / Persistence), plus a tip on the `/auth?form=true` escape hatch.
- `docs/features/authentication-access/auth/sso/index.mdx` — new row in the OAuth Configuration Overview table.

## Verification

Full `npm run build` (Docusaurus) passes with these changes.

Targets `dev` so the docs stage alongside the unreleased feature.