### PR TITLE
docs: clarify supported Python versions

### DIFF
--- a/docs/getting-started/quick-start/tab-python/Pip.md
+++ b/docs/getting-started/quick-start/tab-python/Pip.md
@@ -2,6 +2,8 @@
 
 The simplest way to install Open WebUI with Python.
 
+Open WebUI supports Python 3.11 and 3.12. Use one of these versions before installing with pip.
+
 #### 1. Install Open WebUI
 
 ```bash

--- a/docs/getting-started/quick-start/tab-python/Uv.md
+++ b/docs/getting-started/quick-start/tab-python/Uv.md
@@ -20,7 +20,7 @@ Pick the appropriate installation command for your operating system:
 
 #### 2. Run Open WebUI
 
-Once `uv` is installed, running Open WebUI is a breeze. Use the command below, ensuring to set the `DATA_DIR` environment variable to avoid data loss. Example paths are provided for each platform:
+Once `uv` is installed, running Open WebUI is a breeze. Use the command below, ensuring to set the `DATA_DIR` environment variable to avoid data loss. Open WebUI supports Python 3.11 and 3.12; the examples below pin Python 3.11, but you can use Python 3.12 as well. Example paths are provided for each platform:
 
 - **macOS/Linux**:
 


### PR DESCRIPTION
## Summary
- Document that Open WebUI supports Python 3.11 and 3.12 in the pip quick-start path.
- Clarify that the `uvx --python 3.11` examples are pinned examples, and Python 3.12 is also supported.

## Context
The package metadata in `open-webui/open-webui` declares Python support for `>= 3.11, < 3.13.0a1` and includes the Python 3.12 classifier. A prior README-only attempt was closed with maintainer feedback that this needs to be updated from the docs source: https://github.com/open-webui/open-webui/pull/18486#issuecomment-.

## Validation
- `git diff --check`

I also attempted `npm run prettier:check` for the changed markdown files, but this checkout has no `node_modules`, so `prettier` was not available locally.

---

Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
