### PR TITLE
docs: fix Filter UserValves anchor

### DIFF
--- a/docs/features/extensibility/plugin/functions/filter.mdx
+++ b/docs/features/extensibility/plugin/functions/filter.mdx
@@ -144,7 +144,7 @@ The chip being present = the filter is enabled for the next request. The chip be
 
 ---
 
-## ⚙️ Filter Administration & Configuration
+## ⚙️ Filter Administration & Configuration {#filter-administration--configuration}
 
 ### 🌐 Global Filters vs. Model-Specific Filters
 


### PR DESCRIPTION
## Summary
- Add an explicit heading id for the Filter Administration & Configuration section.
- Restore the existing `UserValves` intra-page link target.
- Remove the broken-anchor warning reported during the Docusaurus build.

## Context
The Filter docs link to `#filter-administration--configuration`, but the target heading did not expose that exact id. As a result, `npm run build` reported a broken anchor for `/features/extensibility/plugin/functions/filter`.

## Validation
- `npx prettier --check docs/features/extensibility/plugin/functions/filter.mdx`
- `npm run build`

---

Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
