### PR TITLE
docs: clarify MCP tools in chat API

### DIFF
--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -44,6 +44,31 @@ Access detailed API documentation for different services provided by Open WebUI:
 - **Endpoint**: `POST /api/chat/completions`
 - **Description**: Serves as an OpenAI API compatible chat completion endpoint for models on Open WebUI including Ollama models, OpenAI models, and Open WebUI Function models.
 
+#### Using Open WebUI tools, including MCP, from the API
+
+The chat completions endpoint can run server-side tools when you pass Open WebUI tool IDs in the request body. This includes native Python tools, OpenAPI tool servers, and MCP tool servers that are already configured and enabled in Open WebUI.
+
+1. Configure the tool server in Open WebUI first. For MCP, see [Model Context Protocol (MCP)](/features/extensibility/mcp).
+2. Get the tool ID from the tools list endpoint or the browser network request when enabling the tool in chat. MCP tool server IDs use the `server:mcp:<server-id>` form.
+3. Include the ID in `tool_ids` when calling `/api/chat/completions`:
+
+```bash
+curl -X POST http://localhost:3000/api/chat/completions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama3.1",
+    "messages": [
+      {"role": "user", "content": "Use the configured MCP tool if it helps."}
+    ],
+    "tool_ids": ["server:mcp:YOUR_MCP_SERVER_ID"]
+  }'
+```
+
+Open WebUI checks the caller's access to each selected tool server before resolving the tools. For OAuth-protected MCP servers, the user associated with the API key must have already completed the OAuth authorization flow in the web UI; otherwise the tool connection can fail during the API request.
+
+If your external client sends its own OpenAI-style `tools` array, Open WebUI forwards those caller-provided tool definitions to the model instead of resolving `tool_ids` server-side.
+
 - **Curl Example**:
 
   ```bash


### PR DESCRIPTION
## Summary
- document that `/api/chat/completions` can resolve Open WebUI `tool_ids`
- call out MCP tool server IDs (`server:mcp:<server-id>`) and access checks
- clarify that caller-provided OpenAI-style `tools` arrays bypass server-side `tool_ids` resolution

Closes https://github.com/open-webui/docs/issues/645

## Validation
- `git diff --check`
- static check for the new `tool_ids` / MCP documentation block
- verified against open-webui backend `origin/main` paths: `main.py` stores `tool_ids` / `tool_servers` metadata and `utils/middleware.py` resolves `server:mcp:` tool IDs
