### PR TITLE
Fixes typo in SSO docs page (ENABLE_OAUTH_PERSISTENT_CONFIG)

### DIFF
--- a/docs/features/authentication-access/auth/sso/index.mdx
+++ b/docs/features/authentication-access/auth/sso/index.mdx
@@ -51,7 +51,7 @@ You cannot have Microsoft **and** Google as OIDC providers simultaneously.
 
 1. **WEBUI_URL Must Be Set First**: Configure `WEBUI_URL` in the Admin Panel before enabling OAuth, as it's used for redirect URIs.
 
-2. **Persistent Config Behavior**: When `ENABLE_OAUTH_PERSISTENT_CONFIG=true` (default), OAuth settings are stored in the database after first launch. To change environment variables after initial setup, either:
+2. **Persistent Config Behavior**: When `ENABLE_OAUTH_PERSISTENT_CONFIG=true`, OAuth settings are stored in the database after first launch. To change environment variables after initial setup, either:
    - Set `ENABLE_OAUTH_PERSISTENT_CONFIG=false` to always read from environment variables
    - Update settings through the Admin Panel instead of environment variables
 


### PR DESCRIPTION
The `ENABLE_OAUTH_PERSISTENT_CONFIG` is `False` by default (https://github.com/open-webui/open-webui/blob/02dc3e689ceac915a870b373318b99c029ddf603/backend/open_webui/config.py#L143), but the documentation page says otherwise in the `Critical Configuration Notes` section (also contradicting the variable tables above that say the default is `False`)