### PR TITLE
Document `FILE_IMAGE_COMPRESSION_WIDTH` and `FILE_IMAGE_COMPRESSION_HEIGHT`

### DIFF
--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -3448,14 +3448,14 @@ The `markdown_header` option has been removed from `RAG_TEXT_SPLITTER`. Markdown
 
 - Type: `int`
 - Default: `None`
-- Description: Sets the maximum width, in pixels, used for client-side compression of image files uploaded from chat. When unset, no backend-configured width limit is applied.
+- Description: Sets the maximum width, in pixels, used for client-side compression of image files uploaded. When unset, no backend-configured width limit is applied.
 - Persistence: This environment variable is a `ConfigVar` variable.
 
 #### `FILE_IMAGE_COMPRESSION_HEIGHT`
 
 - Type: `int`
 - Default: `None`
-- Description: Sets the maximum height, in pixels, used for client-side compression of image files uploaded from chat. When unset, no backend-configured height limit is applied.
+- Description: Sets the maximum height, in pixels, used for client-side compression of image files uploaded. When unset, no backend-configured height limit is applied.
 - Persistence: This environment variable is a `ConfigVar` variable.
 
 :::note

--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -3444,6 +3444,26 @@ The `markdown_header` option has been removed from `RAG_TEXT_SPLITTER`. Markdown
 - Description: Sets the maximum number of files that can be uploaded at once for document ingestion.
 - Persistence: This environment variable is a `ConfigVar` variable.
 
+#### `FILE_IMAGE_COMPRESSION_WIDTH`
+
+- Type: `int`
+- Default: `None`
+- Description: Sets the maximum width, in pixels, used for client-side compression of image files uploaded from chat. When unset, no backend-configured width limit is applied.
+- Persistence: This environment variable is a `ConfigVar` variable.
+
+#### `FILE_IMAGE_COMPRESSION_HEIGHT`
+
+- Type: `int`
+- Default: `None`
+- Description: Sets the maximum height, in pixels, used for client-side compression of image files uploaded from chat. When unset, no backend-configured height limit is applied.
+- Persistence: This environment variable is a `ConfigVar` variable.
+
+:::note
+
+These values are exposed through app config and consumed by the frontend chat upload flow for image files. Compression happens client-side with aspect ratio preserved. Non-image file uploads are not affected.
+
+:::
+
 #### `RAG_ALLOWED_FILE_EXTENSIONS`
 
 - Type: `list` of `str`


### PR DESCRIPTION
## Summary
Add missing documentation for the following environment variables in `docs/reference/env-configuration.mdx`:
- `FILE_IMAGE_COMPRESSION_WIDTH`
- `FILE_IMAGE_COMPRESSION_HEIGHT`

## What this changes
- Documents both variables as `ConfigVar` environment variables
- Adds their default value (`None`)
- Clarifies that they control client-side compression limits for chat-uploaded image files
- Notes that non-image file uploads are not affected

## Why
These variables exist in Open WebUI but were not documented in the environment variable reference. This PR fills that gap so users can understand what they do and when they apply.

## Notes
This wording was checked against current upstream behavior:
- the backend exposes these values through app config
- the frontend uses them during chat image upload compression
- aspect ratio is preserved during resizing