### PR TITLE
Correct custom tool documentation for creating error messages

### DIFF
--- a/docs/features/extensibility/plugin/tools/development.mdx
+++ b/docs/features/extensibility/plugin/tools/development.mdx
@@ -1151,7 +1151,11 @@ await __event_emitter__({
 ```python
 await __event_emitter__({
     "type": "chat:message:error",
-    "data": {"content": "Error message to display"}
+    "data": {
+        "error": {
+            "content": "Error message to display"
+        }
+    }
 })
 ```
 


### PR DESCRIPTION
The current documentation for creating error messages with custom tools using event emitters is incorrect. At the moment the following is written at https://docs.openwebui.com/features/extensibility/plugin/tools/development:

```python
await __event_emitter__({
    "type": "chat:message:error",
    "data": {"content": "Error message to display"}
})
```

However, this doesn't work. When this code is run in a tool, nothing happens on the UI.

I propose to change it to:
```python
await __event_emitter__({
    "type": "chat:message:error",
    "data": {
        "error": {
            "content": "Error message to display"
        }
    }
})
```

Testing this, it does show an error message below the agent response.

Note: I'm new to making pull requests, so feedback is appreciated.