### PR TITLE
docs: add sequential model switching use case

### DIFF
--- a/docs/features/chat-conversations/chat-features/multi-model-chats.mdx
+++ b/docs/features/chat-conversations/chat-features/multi-model-chats.mdx
@@ -23,6 +23,7 @@ In a Multi-Model Chat, your prompt is sent to two or more selected models at the
 *   **Model Comparison/Benchmarking**: Test which model writes better Python code or which one hallucinates less on niche topics.
 *   **Fact Validation**: "Cross-examine" models. If two models say X and one says Y, you can investigate further.
 *   **Diverse Perspectives**: Get a "Creative" take from one model and a "Technical" take from another for the same query.
+*   **Sequential Model Switching**: Move a conversation between models as the task changes. For example, start with a fast local model for brainstorming, switch to a vision model when you attach an image, use a stronger hosted model for synthesis, then switch back to the local model for follow-up edits.
 
 ## Permissions
 
@@ -65,6 +66,4 @@ The merging process relies on the backend **Tasks** system.
 :::info Experimental
 The Merging/MOA feature is an advanced capability. While powerful, it requires a capable Task Model to work effectively.
 :::
-
-
 


### PR DESCRIPTION
## Summary
- add a Sequential Model Switching use case to the multi-model chat docs
- clarify when users might switch models during a single workflow

Closes #26

## Validation
- git diff --check HEAD~1 HEAD