### PR TITLE
docs: add ChinaLLM as OpenAI-compatible provider

### DIFF
--- a/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
+++ b/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
@@ -527,6 +527,24 @@ Each connection has a **toggle switch** that lets you enable or disable it witho
   :::
 
   </TabItem>
+  <TabItem value="chinallm" label="ChinaLLM">
+
+  **ChinaLLM** aggregates 20+ Chinese AI models behind a single OpenAI-compatible API — at a fraction of OpenAI's price.
+
+  | Setting | Value |
+  |---|---|
+  | **URL** | `https://api.chinallm.dev/v1` |
+  | **API Key** | Get yours at [chinallm.dev](https://chinallm.dev) |
+  | **Model IDs** | Auto-detected (e.g., `deepseek-v4-pro`, `qwen-turbo`, `glm-4-flash`, `moonshot-v1-8k`) |
+
+  **Key features:**
+  - Models from **$0.01/M tokens** (GLM-4-Flash) — up to 250x cheaper than GPT-4o
+  - **USDT (TRC20/BSC) and PayPal** accepted — no credit card or KYC required
+  - **$5 minimum top-up**, pay-as-you-go, no monthly commitment
+  - DeepSeek, Qwen, GLM, Kimi, MiniMax, Moonshot, and more
+
+  </TabItem>
+
 </Tabs>
 
 ### Local Servers


### PR DESCRIPTION
ChinaLLM (chinallm.dev) aggregates 20+ Chinese AI models
(DeepSeek, Qwen, GLM, Kimi, MiniMax, Moonshot and more)
behind a single OpenAI-compatible API.

Adding it to the docs helps Open WebUI users discover
an affordable alternative for Chinese LLMs:

- Models from $0.01/M tokens (GLM-4-Flash)
- Fully OpenAI-compatible with working /models endpoint
- Pay with USDT or PayPal, no KYC
- Listed alongside DeepSeek, Groq, Anthropic

Matches the existing provider tab format. No code changes needed.