### PR TITLE
docs(web-search): use canonical YDC_API_KEY for You.com (note YOUCOM_API_KEY fallback)

### DIFF
--- a/docs/features/chat-conversations/web-search/providers/youcom.md
+++ b/docs/features/chat-conversations/web-search/providers/youcom.md
@@ -39,7 +39,7 @@ services:
     environment:
       ENABLE_WEB_SEARCH: True
       WEB_SEARCH_ENGINE: "youcom"
-      YOUCOM_API_KEY: "YOUR_API_KEY"
+      YDC_API_KEY: "YOUR_API_KEY"  # legacy YOUCOM_API_KEY also accepted
       WEB_SEARCH_RESULT_COUNT: 3
       WEB_SEARCH_CONCURRENT_REQUESTS: 10
 ```

--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -4365,11 +4365,11 @@ If you use `perplexity`, this variable is not relevant to you.
 
 :::
 
-#### `YOUCOM_API_KEY`
+#### `YDC_API_KEY`
 
 - Type: `str`
 - Default: Empty string (' ')
-- Description: Sets the API key for [You.com](https://you.com/) YDC Index API web search. Required when `WEB_SEARCH_ENGINE` is set to `youcom`. Obtain an API key from [You.com API](https://you.com/api).
+- Description: Sets the API key for [You.com](https://you.com/) YDC Index API web search. Required when `WEB_SEARCH_ENGINE` is set to `youcom`. Obtain an API key from [You.com API](https://you.com/api). The legacy `YOUCOM_API_KEY` is also accepted as a fallback.
 - Persistence: This environment variable is a `ConfigVar` variable.
 
 ### Web Loader Configuration


### PR DESCRIPTION
## What

Update the You.com web search docs to use the canonical `YDC_API_KEY` environment variable, noting the legacy `YOUCOM_API_KEY` is still accepted.

## Why

`YDC_API_KEY` is You.com's canonical API key env var (used by You.com's own docs/SDK and the LangChain/CrewAI/DSPy integrations). This pairs with open-webui/open-webui#26295, which makes the You.com web search provider prefer `YDC_API_KEY` while keeping `YOUCOM_API_KEY` as a fallback.

## Changes
- `providers/youcom.md`: docker-compose example uses `YDC_API_KEY`.
- `reference/env-configuration.mdx`: documents `YDC_API_KEY`, with `YOUCOM_API_KEY` noted as the legacy fallback.

> Note: best merged after the code PR open-webui/open-webui#26295 lands.

Part of youdotcom-oss/integration-tracking#30
