### PR TITLE
community: remove incorrect 0.9.0 version requirement from Theme Designer Pro entry

### DIFF
--- a/docs/features/extensibility/community.mdx
+++ b/docs/features/extensibility/community.mdx
@@ -104,7 +104,7 @@ A hand-picked set to show what is possible, grouped by plugin type. **Highlighti
 | Plugin | What it does |
 | :--- | :--- |
 | **[Interface Defaults](https://github.com/Classic298/open-webui-plugins/tree/main/interface-defaults)** | Sets your instance's **Settings → Interface** defaults from one function's Valves. New users (signup, OAuth, SCIM) are **seeded automatically** on creation; two one-shot buttons push the defaults to everyone or factory-reset the instance. Native Valves UI, background bulk ops, no custom UI or monkey-patching. Requires Open WebUI 0.10.0. |
-| **[Theme Designer Pro](https://github.com/silentoplayz/theme-designer-pro-presets/tree/main/event-function)** | Instance-wide theme designer that runs as a **standalone admin page** (no chat, no iframe sandbox), persisting CSS and state server-side under `DATA_DIR/theme/` and pushing changes to every connected user in real time over SSE. Includes an OKLCH color engine, draft/publish preview mode, custom-CSS auto-scoping, and login-page theming. Requires Open WebUI v0.9.0+. |
+| **[Theme Designer Pro](https://github.com/silentoplayz/theme-designer-pro-presets/tree/main/event-function)** | Instance-wide theme designer that runs as a **standalone admin page** (no chat, no iframe sandbox), persisting CSS and state server-side under `DATA_DIR/theme/` and pushing changes to every connected user in real time over SSE. Includes an OKLCH color engine, draft/publish preview mode, custom-CSS auto-scoping, and login-page theming. |
 
 ## Before you import: a beginner safety checklist
 


### PR DESCRIPTION
Theme Designer Pro is listed under Event Functions, but Event functions are a plugin primitive introduced in Open WebUI 0.10.0. An Event-type function cannot load on 0.9.0, so the entry's "Requires Open WebUI v0.9.0+" note is incorrect (the plugin's own frontmatter carries the same mistaken required_open_webui_version: 0.9.0). This removes the version line instead of asserting a specific minimum.