### PR TITLE
docs: correct phantom 0.9.7 references to 0.10.0 across Computer, Open Terminal and tool-calling docs

### DIFF
--- a/docs/features/chat-conversations/chat-features/code-execution/python.md
+++ b/docs/features/chat-conversations/chat-features/code-execution/python.md
@@ -68,7 +68,7 @@ When using **Native function calling mode** with a capable model (e.g., GPT-5, C
 **Requirements:**
 1. `ENABLE_CODE_INTERPRETER` must be enabled globally
 2. Model must have `code_interpreter` capability enabled
-3. Model must be in **Native** function calling mode (the default as of v0.9.7; only an issue if it was switched to **Legacy** in the model's advanced params)
+3. Model must be in **Native** function calling mode (the default as of v0.10.0; only an issue if it was switched to **Legacy** in the model's advanced params)
 
 For more details on builtin tools and native mode, see the [Tool Development Guide](/features/extensibility/plugin/tools#built-in-system-tools-nativeagentic-mode).
 

--- a/docs/features/chat-conversations/web-search/agentic-search.mdx
+++ b/docs/features/chat-conversations/web-search/agentic-search.mdx
@@ -33,7 +33,7 @@ To unlock these features, your model must support native tool calling and have s
 2.  **Enable Model Capability**: In **Admin Panel → Settings → Models**, select your model and enable the **Web Search** capability.
 3.  **Enable Default Feature**: In the same model settings, under **Default Features**, check **Web Search**. This controls whether the `search_web` and `fetch_url` tools are available by default in new chat sessions.
 4.  **Confirm Native Mode (Agentic Mode)**:
-    *   Native is the default tool-calling mode as of v0.9.7, so this is already active unless the model was switched to Legacy. In the same model settings, under **Advanced Parameters**, make sure **Function Calling** is set to `Native` (not `Legacy`).
+    *   Native is the default tool-calling mode as of v0.10.0, so this is already active unless the model was switched to Legacy. In the same model settings, under **Advanced Parameters**, make sure **Function Calling** is set to `Native` (not `Legacy`).
 5.  **Use a Quality Model**: Ensure you're using a frontier model with strong reasoning capabilities for best results.
 
 :::info Configuring via environment variables instead

--- a/docs/features/computer/open-webui.md
+++ b/docs/features/computer/open-webui.md
@@ -37,6 +37,6 @@ The `{{...}}` values are Open WebUI's [custom-header placeholders](/reference/en
 - **Branch correctly.** Regenerating or editing a message in Open WebUI creates a matching branch in the cptr sidebar (via `X-OpenWebUI-User-Message-Id` and `X-OpenWebUI-User-Message-Parent-Id`), instead of appending in the wrong place.
 - **Ignore background work.** Open WebUI also calls the gateway for title generation, tag extraction and follow-up suggestions. `X-OpenWebUI-Task` tells cptr which requests are background tasks, so it skips them instead of spawning ghost chats or running a full agent loop.
 
-:::caution Requires Open WebUI 0.9.7 or newer
-The `{{USER_MESSAGE_ID}}`, `{{USER_MESSAGE_PARENT_ID}}` and `{{TASK}}` placeholders were added in Open WebUI 0.9.7. On 0.9.6 the basic gateway connection still works, you can chat with a workspace as a model, but those three headers are not filled in, so branching and background-task filtering do not work yet.
+:::caution Requires Open WebUI 0.10.0 or newer
+The `{{USER_MESSAGE_ID}}`, `{{USER_MESSAGE_PARENT_ID}}` and `{{TASK}}` placeholders were added in Open WebUI 0.10.0. On 0.9.6 the basic gateway connection still works, you can chat with a workspace as a model, but those three headers are not filled in, so branching and background-task filtering do not work yet.
 :::

--- a/docs/features/extensibility/plugin/tools/development.mdx
+++ b/docs/features/extensibility/plugin/tools/development.mdx
@@ -173,7 +173,7 @@ else:
 ```
 
 :::caution Do not check for `"native"` or `"default"`
-Before v0.9.7 an unset model carried `"default"`, and tools detected Native with `function_calling == "native"`. That is now wrong. An unset model runs **Native** but does not carry the string `"native"`, so a `== "native"` test (or treating a `"default"` fallback as non-native) misclassifies the now-default case as Legacy and feeds it Legacy-only events that silently break. Test for `== "legacy"` and treat everything else as Native.
+Before v0.10.0 an unset model carried `"default"`, and tools detected Native with `function_calling == "native"`. That is now wrong. An unset model runs **Native** but does not carry the string `"native"`, so a `== "native"` test (or treating a `"default"` fallback as non-native) misclassifies the now-default case as Legacy and feeds it Legacy-only events that silently break. Test for `== "legacy"` and treat everything else as Native.
 :::
 
 #### Complete Event Type Compatibility Matrix

--- a/docs/features/extensibility/plugin/tools/index.mdx
+++ b/docs/features/extensibility/plugin/tools/index.mdx
@@ -104,8 +104,8 @@ Attaching a workspace tool to a model does **not** bypass access control. When a
 
 ## Tool Calling Modes: Native vs. Legacy {#tool-calling-modes-default-vs-native}
 
-:::danger Native is the default as of v0.9.7; "Legacy" (formerly "Default") is the unsupported opt-out
-**Native (Agentic) Mode is now the default.** As of **v0.9.7**, every chat and model that has not explicitly chosen a tool-calling mode runs **Native**, which relies on the model's built-in function-calling support. The old prompt-injection approach, previously called **Default**, is now renamed **Legacy**. It is the explicit opt-out and remains **unsupported**: no feature work, no bug fixes, no built-in system tools, and incompatible with modern Open WebUI features (Agentic Research, Interleaved Thinking, the built-in Memory/Notes/Knowledge/Channels tools, and web-search/image-gen/code-interpreter tool injection).
+:::danger Native is the default as of v0.10.0; "Legacy" (formerly "Default") is the unsupported opt-out
+**Native (Agentic) Mode is now the default.** As of **v0.10.0**, every chat and model that has not explicitly chosen a tool-calling mode runs **Native**, which relies on the model's built-in function-calling support. The old prompt-injection approach, previously called **Default**, is now renamed **Legacy**. It is the explicit opt-out and remains **unsupported**: no feature work, no bug fixes, no built-in system tools, and incompatible with modern Open WebUI features (Agentic Research, Interleaved Thinking, the built-in Memory/Notes/Knowledge/Channels tools, and web-search/image-gen/code-interpreter tool injection).
 
 **Breaking change:** if any of your models depended on the old prompt-based behavior, they now run Native unless you switch them back to **Legacy**, per chat, per model, or globally in your default model parameters. If a model struggles with Native, the right fix is a stronger tool-calling model, not falling back to Legacy.
 :::
@@ -128,7 +128,7 @@ Why it is legacy:
 - **Does not support modern capabilities.** Every new feature shipped since 2024 targets Native Mode.
 
 ### 🟢 Native Mode (Agentic Mode / System Function Calling): The Only Supported Mode
-Native Mode (also called **Agentic Mode**) leverages the model's built-in capability to handle tool definitions and return structured tool calls (JSON). It is the **default** as of v0.9.7 and the **recommended mode** for all models that support it, which includes the vast majority of modern models (2024+).
+Native Mode (also called **Agentic Mode**) leverages the model's built-in capability to handle tool definitions and return structured tool calls (JSON). It is the **default** as of v0.10.0 and the **recommended mode** for all models that support it, which includes the vast majority of modern models (2024+).
 
 :::warning Model Quality Matters
 **Agentic tool calling requires high-quality models to work reliably.** While small local models may technically support function calling, they often struggle with the complex reasoning required for multi-step tool usage. For best results, use frontier models like **GPT-5**, **Claude 4.5 Sonnet**, **Gemini 3 Flash**, or **MiniMax M2.5**. Small local models may produce malformed JSON or fail to follow the strict state management required for agentic behavior.
@@ -143,7 +143,7 @@ Native Mode (also called **Agentic Mode**) leverages the model's built-in capabi
 - **System Tools**: Only Native Mode unlocks the [built-in system tools](#built-in-system-tools-nativeagentic-mode) (memory, notes, knowledge, channels, etc.).
 
 #### How to Enable Native Mode (Agentic Mode)
-Native Mode is the **default** as of v0.9.7, so new and existing models use it unless they are explicitly set to Legacy. You can still set `Function Calling` explicitly (to pin Native, or to switch a model to Legacy) at these levels:
+Native Mode is the **default** as of v0.10.0, so new and existing models use it unless they are explicitly set to Legacy. You can still set `Function Calling` explicitly (to pin Native, or to switch a model to Legacy) at these levels:
 
 1.  **Universal Default for Every Model (Fastest, Recommended)**:
     *   Navigate to **Admin Panel → Settings → Models**.

--- a/docs/features/open-terminal/index.md
+++ b/docs/features/open-terminal/index.md
@@ -80,7 +80,7 @@ Bulk rename, sort, deduplicate, convert, compress, and organize files. Manage di
 **[Installation →](./setup/installation)** · **[Connect to Open WebUI →](./setup/connecting)**
 
 :::info Model requirements
-Open Terminal needs a model that does tool calling at agentic quality, not just one that technically supports it. Driving a terminal is a multi-step loop: call a tool, read the output, decide the next command, repeat, often for many turns. Small models cannot sustain that. A 4B to 9B model will not cut it here, even if it ticks the "supports tools" box. Frontier models (GPT-5.4, Claude Sonnet 4.6, Gemini 3.1 Pro) handle these complex multi-step workflows well. Native is the default tool-calling mode as of v0.9.7, so it works out of the box unless the model was switched to Legacy; [check the model's tool-calling mode](./setup/connecting#8-enable-native-function-calling) if tools are not firing.
+Open Terminal needs a model that does tool calling at agentic quality, not just one that technically supports it. Driving a terminal is a multi-step loop: call a tool, read the output, decide the next command, repeat, often for many turns. Small models cannot sustain that. A 4B to 9B model will not cut it here, even if it ticks the "supports tools" box. Frontier models (GPT-5.4, Claude Sonnet 4.6, Gemini 3.1 Pro) handle these complex multi-step workflows well. Native is the default tool-calling mode as of v0.10.0, so it works out of the box unless the model was switched to Legacy; [check the model's tool-calling mode](./setup/connecting#8-enable-native-function-calling) if tools are not firing.
 :::
 
 ---

--- a/docs/features/open-terminal/setup/connecting.md
+++ b/docs/features/open-terminal/setup/connecting.md
@@ -69,7 +69,7 @@ The selected terminal name appears next to the cloud icon. The AI can now execut
 
 ### 8. Enable native function calling
 
-Native function calling is the default tool-calling mode as of v0.9.7, so it is already active for new models. The only thing to check is that the model was not switched to **Legacy**:
+Native function calling is the default tool-calling mode as of v0.10.0, so it is already active for new models. The only thing to check is that the model was not switched to **Legacy**:
 
 1. Go to **Workspace → Models**
 2. Click the edit button on the model you're using


### PR DESCRIPTION
Native tool calling became the default in Open WebUI 0.10.0 (not 0.9.7), and the {{USER_MESSAGE_ID}} / {{USER_MESSAGE_PARENT_ID}} / {{TASK}} header variables also landed in 0.10.0. There was no 0.9.7 release (0.9.6 was followed directly by 0.10.0), so every doc claim attributing these to 0.9.7 referenced a version that never shipped. Verified against the upstream CHANGELOG. This corrects the phantom 0.9.7 references to 0.10.0 across the Computer, Open Terminal, code-execution, web-search and tool-calling docs (7 files).