### PR TITLE
docs: add DaoXE to OpenAI-compatible provider guide

### DIFF
--- a/docs/getting-started/quick-start/connect-a-provider/index.md
+++ b/docs/getting-started/quick-start/connect-a-provider/index.md
@@ -46,7 +46,7 @@ Hosted APIs that require an account and API key. No hardware needed.
 | **Ollama** | Llama, Mistral, Gemma, Phi, and thousands more (local) | [Starting with Ollama →](./starting-with-ollama) |
 | **OpenAI** | GPT-4o, GPT-4.1, o3, o4-mini | [Starting with OpenAI →](./starting-with-openai) |
 | **Anthropic** | Claude Opus, Sonnet, Haiku | [Starting with Anthropic →](./starting-with-anthropic) |
-| **OpenAI-Compatible** | Google Gemini, DeepSeek, Mistral, Groq, OpenRouter, Amazon Bedrock, Azure, and more | [OpenAI-Compatible Providers →](./starting-with-openai-compatible) |
+| **OpenAI-Compatible** | Google Gemini, DeepSeek, Mistral, Groq, OpenRouter, DaoXE, Amazon Bedrock, Azure, and more | [OpenAI-Compatible Providers →](./starting-with-openai-compatible) |
 
 ---
 

--- a/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
+++ b/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
@@ -225,6 +225,22 @@ Each connection has a **toggle switch** that lets you enable or disable it witho
   :::
 
   </TabItem>
+
+  <TabItem value="daoxe" label="DaoXE">
+
+  **DaoXE** is a multi-model multi-protocol AI API gateway. Connect through an OpenAI-compatible base URL and discover the models available to your API key. DaoXE also supports OpenAI Responses and Anthropic Messages endpoints outside Open WebUI's Chat Completions path.
+
+  | Setting | Value |
+  |---|---|
+  | **URL** | `https://daoxe.com/v1` |
+  | **API Key** | Your API key from [daoxe.com](https://daoxe.com) |
+  | **Model IDs** | Auto-detected via `/models` for the authenticated key; filter if the catalog is large |
+
+  :::note
+  DaoXE is **not available in mainland China**. Public setup examples: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI).
+  :::
+
+  </TabItem>
   <TabItem value="bedrock" label="Amazon Bedrock">
 
   **Amazon Bedrock** is a fully managed AWS service that provides access to foundation models from leading AI companies (Anthropic, Meta, Mistral, Cohere, Stability AI, Amazon, and more) through a single API.


### PR DESCRIPTION
## Summary
- Add a **DaoXE** tab under Cloud Providers in the OpenAI-compatible connection guide.
- URL: `https://daoxe.com/v1` with authenticated `/models` discovery.
- Clarify multi-protocol scope (Chat Completions path used by Open WebUI; DaoXE also exposes Responses/Anthropic Messages elsewhere).
- Note that DaoXE is not available in mainland China.
- Mention DaoXE in the Connect a Provider overview table.

## Disclosure
I am affiliated with DaoXE.
Public examples: https://github.com/seven7763/DaoXE-AI

## Test plan
- [ ] Preview the MDX tab renders correctly
- [ ] Links to daoxe.com and DaoXE-AI resolve