### PR TITLE
docs: document OpenAI-compatible /ollama/v1/embeddings endpoint

### DIFF
--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -396,6 +396,28 @@ curl -X POST http://localhost:3000/ollama/v1/responses \
 
 This allows API consumers (Codex, Claude Code, etc.) to use the Responses API directly with Ollama-hosted models without configuring a separate OpenAI-compatible connection.
 
+#### 🧩 Embeddings API (OpenAI-Compatible)
+
+Ollama also supports the OpenAI-compatible `/v1/embeddings` format. Open WebUI proxies this through the Ollama router with the same model resolution, access control, and prefix handling used by chat completions and the Responses API above, so `openai.embeddings.create()` works out of the box against an Ollama-backed model instead of requiring the native `/ollama/api/embed` format shown earlier.
+
+```bash
+curl -X POST http://localhost:3000/ollama/v1/embeddings \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "model": "nomic-embed-text",
+  "input": "Why is the sky blue?"
+}'
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:3000/ollama/v1", api_key="YOUR_API_KEY")
+response = client.embeddings.create(model="nomic-embed-text", input="Why is the sky blue?")
+print(response.data[0].embedding[:5])
+```
+
 This is ideal for building search indexes, retrieval systems, or custom pipelines using Ollama models behind the Open WebUI.
 
 ### 🧩 Retrieval Augmented Generation (RAG)


### PR DESCRIPTION
### Description

Adds documentation for the OpenAI-compatible `/ollama/v1/embeddings` proxy endpoint, which was added to Open WebUI in open-webui/open-webui#27332. This lets `openai.embeddings.create()` work directly against an Ollama-backed model through Open WebUI, matching the existing documented pattern for the OpenAI-compatible `/ollama/v1/responses` endpoint just above it in this same section.

### Related

- Discussion: https://github.com/open-webui/open-webui/discussions/27328
- Code PR: open-webui/open-webui#27332

### Changes

- `docs/reference/api-endpoints.md`: added a new "🧩 Embeddings API (OpenAI-Compatible)" subsection under "🦙 Ollama API Proxy Support", with `curl` and Python (`openai` SDK) examples, following the same structure as the existing Responses API subsection.

Otherwise this is ready to submit.
