### PR TITLE
docs: Fix alternatives table overflow on mobile

### DIFF
--- a/docs/alternatives/index.mdx
+++ b/docs/alternatives/index.mdx
@@ -41,6 +41,8 @@ We get asked "what else is out there?" a lot, so we put this list together. If O
 
 ## All Alternatives
 
+<div className="responsive-table">
+
 | Tool | What It's Great For | License | Works with Open WebUI | |
 | :--- | :--- | :--- | :--- | :--- |
 | **Ollama** | The most popular way to run local models | Open Source (MIT) | Native integration | [Learn more →](/alternatives/ollama) |
@@ -55,6 +57,8 @@ We get asked "what else is out there?" a lot, so we put this list together. If O
 | **ChatGPT / OpenAI** | The one that started it all, we use it daily | Commercial (free tier) | Via OpenAI API | [Learn more →](/alternatives/chatgpt) |
 | **Claude / Anthropic** | Exceptional writing and reasoning, we use it daily | Commercial (free tier) | Via Anthropic API | [Learn more →](/alternatives/claude) |
 | **Gemini / Google** | Multimodal AI with Google ecosystem integration | Commercial (free tier) | Via Google AI API | [Learn more →](/alternatives/gemini) |
+
+</div>
 
 Open WebUI itself contains code under [multiple licenses](/license). The latest components are under the Open WebUI License, which includes a branding preservation requirement, while prior contributions retain their respective original license terms.
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -684,6 +684,16 @@ div.special_table + table tr td {
 	padding-top: 0.45rem;
 	padding-bottom: 0.45rem;
 }
+
+@media screen and (width <= 996px) {
+	.responsive-table {
+		overflow-x: auto;
+	}
+
+	.responsive-table > table {
+		min-width: 48rem;
+	}
+}
 /* stylelint-enable no-descending-specificity */
 
 /* ─── Custom tags ─── */


### PR DESCRIPTION
## Summary

- Wrap the Alternatives comparison table in the reusable `.responsive-table` container.
- Enable horizontal scrolling below the Docusaurus mobile breakpoint so all columns remain readable on narrow screens.
- Limit the change to this table; desktop layout and other documentation tables are unchanged.

## Testing

- `npm run lint -- --max-warnings=0`
- `npm run build`
- Verified change works on mobile view