### PR TITLE
docs: clarify local RAG document selection instructions

### DIFF
--- a/docs/features/chat-conversations/rag/index.md
+++ b/docs/features/chat-conversations/rag/index.md
@@ -27,7 +27,7 @@ One of the key advantages of RAG is its ability to access and integrate informat
 
 ## Local and Remote RAG Integration
 
-Local documents must first be uploaded via the Documents section of the Workspace area to access them using the `#` symbol before a query. Click on the formatted URL in the that appears above the chat box. Once selected, a document icon appears above `Send a message`, indicating successful retrieval.
+To use a local document in RAG, upload it from the Documents section in the Workspace area. In a chat, type `#` before your query and select the uploaded document from the suggestion box that appears above the message input. Once selected, a document icon appears above `Send a message`, indicating that the document has been attached for retrieval.
 
 :::tip Bulk File Management
 Need to clean up multiple uploaded documents or audit your storage? You can now use the centralized **[File Manager](/features/chat-conversations/data-controls/files)** located in **Settings > Data Controls > Manage Files**. Deleting files there will automatically clean up their corresponding RAG embeddings.


### PR DESCRIPTION
## Summary

Clarifies the local RAG document selection instructions in the RAG documentation.

## Changes

- Reworded the local document selection paragraph
- Fixed an unclear phrase in the existing instructions
- Clarified that users should type `#` in chat and select the uploaded document from the suggestion box

## Testing

- Reviewed the Markdown formatting locally
- Verified the change only affects the RAG documentation wording