### PR TITLE
docs: clarify Docling async processing and timeout config in RAG troubleshooting

### DIFF
--- a/docs/troubleshooting/rag.mdx
+++ b/docs/troubleshooting/rag.mdx
@@ -98,6 +98,8 @@ This is the most common problem, and it's typically caused by issues during cont
 
 Try uploading a document and preview the extracted content. If it's blank or missing key sections, you need to adjust your extractor settings or use a different engine.
 
+**Note on Docling:** When using Docling for large or scanned PDFs, uploads may take longer because Docling processes files asynchronously. By default, Open WebUI waits indefinitely. To prevent timeouts on very large documents, you can increase the **Docling Serve Timeout** setting (in **Admin > Tools > Documents**) to give long conversions more time. For small documents, the default behavior is typically fine.
+
 :::
 
 ---


### PR DESCRIPTION
Add a note explaining that Docling processes files asynchronously and may take longer for large/scanned PDFs, with a reference to the Docling Serve Timeout setting for users who encounter timeouts. Positioned in the content-extraction troubleshooting section where users checking extraction quality will naturally find it.

This is related to https://github.com/open-webui/open-webui/pull/26947 