### PR TITLE
docs: Documents the knowledge base upload limits added as a global admin setting.

### DIFF
--- a/docs/features/workspace/knowledge.mdx
+++ b/docs/features/workspace/knowledge.mdx
@@ -339,3 +339,12 @@ Files uploaded via API are processed asynchronously. Attempting to use a file be
 ### Native function calling changes behavior
 
 Native function calling is now the default, and it changes how knowledge bases work: attached KBs are no longer auto-injected, so the model must call the knowledge tools to retrieve them. See [Knowledge Base troubleshooting](/troubleshooting/rag#13-knowledge-base-attached-to-model-not-working) for details.
+
+### Knowledge base upload limits
+
+Administrators can cap how many files a single knowledge base may hold and how large each file may be, in **Admin Panel > Settings > Documents > Max Knowledge Base Files / Max Knowledge Base File Size**, alongside the general upload settings.
+
+- `0` or empty means unlimited.
+- These are global settings that apply to every knowledge base and every user, including admins — there is no per-user or per-group override.
+
+These limits are enforced server-side for every way of adding files to a knowledge base — the manual upload button, the one-shot **Upload Directory** import, incremental directory sync, and the API — not just the primary upload form, so a user can't work around them by switching upload methods. If a limit is hit you'll see an error before any file processing begins.

--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -3865,6 +3865,20 @@ The `markdown_header` option has been removed from `RAG_TEXT_SPLITTER`. Markdown
 - Description: Sets the maximum number of files that can be uploaded at once for document ingestion.
 - Persistence: This environment variable is a `ConfigVar` variable.
 
+#### `RAG_KNOWLEDGE_MAX_SIZE`
+
+- Type: `int`
+- Default: `None` (unlimited)
+- Description: Sets the maximum size, in MB, of a single file that can be added to a knowledge base. `0` also means unlimited. Applies to every way of adding a file to a knowledge base (manual upload, directory upload, directory sync, and the API). Configurable in **Admin Panel → Settings → Documents → Max Knowledge Base File Size**.
+- Persistence: This environment variable is a `ConfigVar` variable.
+
+#### `RAG_KNOWLEDGE_MAX_COUNT`
+
+- Type: `int`
+- Default: `None` (unlimited)
+- Description: Sets the maximum number of files allowed in a single knowledge base. `0` also means unlimited. Configurable in **Admin Panel → Settings → Documents → Max Knowledge Base Files**.
+- Persistence: This environment variable is a `ConfigVar` variable.
+
 #### `RAG_FILE_CONTENT_SEARCH_MAX_CHARS`
 
 - Type: `int`

--- a/docs/troubleshooting/rag.mdx
+++ b/docs/troubleshooting/rag.mdx
@@ -204,7 +204,7 @@ Open WebUI implements various limits to ensure system stability and prevent abus
     *   **Allowed File Extensions:** Controlled by `RAG_ALLOWED_FILE_EXTENSIONS` (default: All). Configurable in **Settings > Admin > Tools > Documents > General > Allowed File Extensions**.
 *   **Folder Uploads:** Subject to the `FOLDER_MAX_FILE_COUNT` [environment variable](/reference/env-configuration/#folder_max_file_count) (defaults to 100). This limit applies to the number of files directly associated with a folder.
 *   **Knowledge Base Uploads:**
-    *   **File Limit:** Subject to the same `RAG_FILE_MAX_SIZE` limit as chats, but **not** subject to the `RAG_FILE_MAX_COUNT` limit, allowing for unlimited file uploads.
+    *   **File Limit:** Subject to the same `RAG_FILE_MAX_SIZE` limit as chats (not `RAG_FILE_MAX_COUNT`, which only applies to chat attachments), plus two knowledge-base-specific limits: `RAG_KNOWLEDGE_MAX_SIZE` (max size per file, default unlimited) and `RAG_KNOWLEDGE_MAX_COUNT` (max files per knowledge base, default unlimited). Both are configurable in **Settings > Admin > Tools > Documents > Files > Max Knowledge Base File Size / Max Knowledge Base Files** and apply to every upload method (manual upload, directory upload/sync, and the API).
     *   **RAG Enforcement:** All files uploaded to a Knowledge Base are automatically indexed. However, similar to chat uploads, Knowledge Bases can also be used in **Full Context Mode** (accessible in chat settings), which feeds the full document content to the model instead of using vector search retrieval.
 
 :::info


### PR DESCRIPTION
Documents the knowledge base upload limits added as a global admin setting.

Corresponding open-webui PR: https://github.com/open-webui/open-webui/pull/28142

### Changes

- **`docs/features/workspace/knowledge.mdx`** — new "Knowledge base upload limits" section under Limitations: what the limits do, `0`/empty = unlimited, that they're global (apply to every knowledge base and every user, including admins, with no per-user or per-group override), and that enforcement is server-side across every upload path (manual button, one-shot directory import, incremental sync, and the API).
- **`docs/reference/env-configuration.mdx`** — adds `RAG_KNOWLEDGE_MAX_SIZE` and `RAG_KNOWLEDGE_MAX_COUNT` entries, alongside the existing `RAG_FILE_MAX_SIZE` / `RAG_FILE_MAX_COUNT` entries they're modeled on.
- **`docs/troubleshooting/rag.mdx`** — updates the existing "Upload Limits and Restrictions" section, which previously documented knowledge base uploads as having no count limit at all.

### Related

- Discussions: open-webui/discussions#24075, open-webui/discussions#24845
