### PR TITLE
Add QVAC to the Local Servers section

### DIFF
--- a/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
+++ b/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
@@ -633,6 +633,25 @@ Each connection has a **toggle switch** that lets you enable or disable it witho
   See the [Docker Model Runner docs](https://docs.docker.com/ai/model-runner/) for setup instructions.
 
   </TabItem>
+  <TabItem value="qvac" label="QVAC">
+
+  **QVAC** is an end-to-end platform for local AI. It ships an OpenAI-compatible HTTP server via its CLI that you can use as a local model provider.
+
+  | Setting | Value |
+  |---|---|
+  | **URL** | `http://localhost:11434/v1` |
+  | **API Key** | Leave blank |
+
+  **Quick start:**
+
+  ```bash
+  npm i -g @qvac/cli
+  qvac serve openai
+  ```
+
+  See the [QVAC docs](https://docs.qvac.tether.io/cli/http-server/connection) for how to register models under `serve.models` and for the full endpoint list.
+
+  </TabItem>
 </Tabs>
 
 :::tip Connection Timeout Configuration


### PR DESCRIPTION
## What

Adds a **QVAC** tab under the **Local Servers** section of `getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx`.

## Why

[QVAC](https://docs.qvac.tether.io) is an end-to-end platform for local AI. Its CLI (`@qvac/cli`) ships an OpenAI-compatible HTTP server (`qvac serve openai`) that implements `/v1/chat/completions`, `/v1/models`, and the other OpenAI routes, so Open WebUI users can connect to it the same way they already do with Llama.cpp, LM Studio, LocalAI, etc.

Defaults used in the tab:

- URL: `http://localhost:11434/v1`
- API key: none (blank).
- `/v1/models` is implemented, so Open WebUI's model auto-detection works once models are loaded under `serve.models`.

The tab is intentionally lean and matches the shape of the neighboring Local Servers entries (Lemonade, LM Studio, LocalAI, Docker Model Runner). More detailed setup (registering models, other endpoints such as embeddings, TTS, transcription, images, video) is linked to the [QVAC docs](https://docs.qvac.tether.io/cli/http-server/connection).

## Preview

The new tab renders at the end of the **Local Servers** tab list on [`/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible/#local-servers`](https://docs.openwebui.com/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible/#local-servers).
