### PR TITLE
Fix link to notifications and webhooks section

### DIFF
--- a/docs/ecosystem/computer/automate/scheduled-tasks.md
+++ b/docs/ecosystem/computer/automate/scheduled-tasks.md
@@ -35,7 +35,7 @@ Every run creates:
 - a **real chat** in the selected workspace, visible in the sidebar with the full task activity, and
 - a **run-history entry** on the task showing success or error (with the error text).
 
-Want a ping? Add a notification target once, then just put the condition in the task's prompt ("notify me only if it fails"): the agent has a notify tool and decides when to use it. Blanket event pings on every finished/failed run exist too. See [notifications and webhooks](./notifications).
+Want a ping? Add a notification target once, then just put the condition in the task's prompt ("notify me only if it fails"): the agent has a notify tool and decides when to use it. Blanket event pings on every finished/failed run exist too. See [notifications and webhooks](../notifications).
 
 ## Trigger a task with a webhook
 


### PR DESCRIPTION
Updated link to notifications documentation.

## Summary

just a wrong link.

<!-- Briefly describe what this PR changes and why it benefits Open WebUI users. -->

## Related issue or discussion

the link to webhooks and notifications on:

https://docs.openwebui.com/ecosystem/computer/automate/scheduled-tasks/

leads to 404 error.

<!-- Link the issue or discussion this PR resolves, if one exists. -->

## Checklist

- [x] I have reviewed the relevant documentation and matched the existing style.
- [x] This PR meets Open WebUI's contribution standards: it is accurate, relevant to users, narrowly scoped, maintainable, and not promotional content, advertising, lead generation, SEO placement, or a request to list a product, service, provider, integration, gateway, tool, or company primarily for visibility.
- [x] I understand that PRs that do not meet these standards may be closed without review and will not be merged. Repeated, low-quality, off-topic, promotional, or intentionally misleading submissions may result in the contributor being blocked from future participation in Open WebUI repositories.

## Notes for reviewers

<!-- Add screenshots, validation steps, or other context reviewers should know. -->
