### PR TITLE
docs: add Synthorai to the OpenAI-compatible cloud providers

### DIFF
--- a/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
+++ b/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
@@ -252,6 +252,21 @@ Each connection has a **toggle switch** that lets you enable or disable it witho
   :::
 
   </TabItem>
+  <TabItem value="synthorai" label="Synthorai">
+
+  **Synthorai** provides a single OpenAI-compatible endpoint for models from multiple upstream providers, with per-key model permissions and spend limits.
+
+  | Setting | Value |
+  |---|---|
+  | **URL** | `https://synthorai.io/v1` |
+  | **API Key** | Your API key from the [Synthorai console](https://synthorai.io/docs/quickstart/) |
+  | **Model IDs** | Auto-detected, leave empty or filter to specific models |
+
+  :::tip
+  `/models` returns the models **your key is permitted to use**, not the whole catalog, so the list you see depends on the key. If a model you expect is missing, check that key's model permissions rather than adding the ID by hand. The [model catalog](https://synthorai.io/models/) lists what is available overall.
+  :::
+
+  </TabItem>
   <TabItem value="openrouter" label="OpenRouter">
 
   **OpenRouter** aggregates hundreds of models from multiple providers behind a single API.


### PR DESCRIPTION
**Disclosure: I am affiliated with Synthorai** — this adds our own product to the provider list, not demand I am relaying from elsewhere. Flagging it so the change is judged with that on the table. No expectation of priority, and "not now" is a fine answer.

This PR was prepared with an AI agent. Every factual claim below is backed by a command I ran; where something was not verified, that is said outright.

## Why here

Synthorai speaks the OpenAI Chat Completions protocol, so it needs no core code — which is the case this page exists for. Per **Protocol-Oriented Design**, gateways belong here rather than in a provider-specific module, and `OpenRouter` and `Vercel AI Gateway` already have tabs.

## What changed

One `<TabItem>` in `starting-with-openai-compatible.mdx`, inside `### Cloud Providers`, placed between `Vercel AI Gateway` and `OpenRouter` so the gateway entries stay together. One file, 15 added lines, nothing removed or reordered.

Shape mirrors the `Vercel AI Gateway` tab: bold lead sentence, the three-row settings table, one `:::tip`.

## The one claim I measured rather than assumed

The tab states `/models` auto-detection works, which this page documents for every provider. I tested it against a real key rather than inferring it:

```
GET /v1/models  + Bearer <key>   →  HTTP 200, 67 models, each with id/object/owned_by
```

**Two things worth flagging, because they change what the tip should say:**

1. **`/models` returns what the key is permitted to use, not the full catalog.** The key I tested returned 67 of the 113 models in our public catalog; the difference is that key's model permissions, not endpoint behaviour. So the tip tells readers to check key permissions rather than hand-adding IDs — hand-adding an ID the key cannot use produces a model that appears in the selector and then fails on send.

2. **A 401 from this endpoint proves nothing about it.** Our auth sits on the `/v1` prefix, so an unrouted path answers 401 too:

   ```
   /v1/models        (no auth) → 401
   /v1/definitely-not-real     → 401
   ```

   I mention it only because your warning box reasonably treats a 401 during connection verification as a signal. For this gateway it is not one, and the tab does not ask readers to interpret it.

The list is small enough that the allowlist-and-caching advice in the OpenRouter tab does not apply here, so it is not repeated.

## Deliberately not done

- **No row added to the "Providers with known `/models` issues" table.** That table's stated subject is known issues, and this endpoint has none. Happy to add a `| Synthorai | Yes | Auto-detection works |` row if you would rather the table stay exhaustive.
- **JS/other pages untouched.**
- **No screenshots.** Neighbouring tabs in this file carry none.

## Note on the precedent I was following

The last external provider addition I found here is #1054 (`sylviezhang37`, merged 2026-02-12), which edited `docs/getting-started/quick-start/starting-with-openai.mdx` — two one-line lists. **That file no longer exists**; the docs were reorganised and providers moved to this page as tabs with settings tables. So I followed the current file's conventions rather than that diff's shape. Saying so in case the older pattern is what you expect.

## Where to look

The tip wording. It carries the only non-obvious claim in the change, and if "permitted to use" reads oddly for this page's audience I will reword it.
