### PR TITLE
Add Arize AX collector guidance to OpenTelemetry docs

### DIFF
--- a/docs/reference/monitoring/otel.md
+++ b/docs/reference/monitoring/otel.md
@@ -5,6 +5,8 @@ title: "OpenTelemetry"
 
 Open WebUI supports **distributed tracing and metrics** export via the OpenTelemetry (OTel) protocol (OTLP). This enables integration with modern observability stacks such as **Grafana LGTM (Loki, Grafana, Tempo, Mimir)**, as well as **Jaeger**, **Tempo**, and **Prometheus** to monitor requests, database/Redis queries, response times, and more in real-time.
 
+For AI application observability backends that require custom OTLP headers, such as [Arize AX](https://arize.com/docs/ax/integrations/platforms/openwebui/openwebui-tracing), point Open WebUI at an OpenTelemetry Collector and let the collector forward traces with the required authentication headers.
+
 :::warning Additional Dependencies
 
 If you are running Open WebUI from source or via `pip` (outside of the official Docker images), OpenTelemetry dependencies **may not be installed by default**. You may need to install them manually:
@@ -121,6 +123,42 @@ docker run -d --name open-webui \
   -e OTEL_SERVICE_NAME=open-webui \
   -v open-webui:/app/backend/data \
   ghcr.io/open-webui/open-webui:main
+```
+
+### Forward traces through a collector
+
+Some OTLP backends require custom headers that are better handled in an OpenTelemetry Collector. For example, Arize AX
+requires `space_id` and `api_key` headers on its OTLP exporter. Point Open WebUI at the collector, then configure the
+collector to add the backend-specific headers:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+  resource/arize_project:
+    attributes:
+      - key: openinference.project.name
+        value: open-webui
+        action: upsert
+
+exporters:
+  otlphttp/arize:
+    endpoint: https://otlp.arize.com/v1
+    headers:
+      space_id: ${env:ARIZE_SPACE_ID}
+      api_key: ${env:ARIZE_API_KEY}
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resource/arize_project, batch]
+      exporters: [otlphttp/arize]
 ```
 
 ## 🚨 Troubleshooting


### PR DESCRIPTION
## Summary

- Document how to forward Open WebUI's built-in OpenTelemetry traces through a collector when an OTLP backend requires custom authentication headers.
- Use Arize AX as a concrete example because it requires `space_id` and `api_key` exporter headers that Open WebUI cannot configure directly.
- Clarify that this path exports backend service telemetry; rich prompt, response, token, and tool-call traces require separate instrumentation on the model-provider or Pipeline path.

This benefits self-hosted Open WebUI operators who already use the documented OTLP export but cannot connect directly to a backend requiring non-basic-auth headers. The collector pattern is reusable for other OTLP backends with custom-header requirements.

## Related issue or discussion

No linked issue. This extends the existing **Custom Collector Setup** and **Authentication required?** sections of the OpenTelemetry reference.

## Checklist

- [x] I have reviewed the relevant documentation and matched the existing style.
- [x] This PR meets Open WebUI's contribution standards: it is accurate, relevant to users, narrowly scoped, maintainable, and not promotional content, advertising, lead generation, SEO placement, or a request to list a product, service, provider, integration, gateway, tool, or company primarily for visibility.
- [x] I understand that PRs that do not meet these standards may be closed without review and will not be merged. Repeated, low-quality, off-topic, promotional, or intentionally misleading submissions may result in the contributor being blocked from future participation in Open WebUI repositories.

## Notes for reviewers

- Rebased through a normal merge with current `main`; the content change remains confined to `docs/reference/monitoring/otel.md`.
- The collector configuration matches Open WebUI's current OTLP/gRPC setup and uses an `otlphttp` exporter to add backend-specific headers.
- `npx prettier@3.3.3 docs/reference/monitoring/otel.md --check` passes.
- `git diff --check` passes.
