### PR TITLE
docs: correct OFFLINE_MODE scope and document the requirements skip

### DIFF
--- a/docs/getting-started/advanced-topics/hardening.md
+++ b/docs/getting-started/advanced-topics/hardening.md
@@ -535,7 +535,9 @@ For air-gapped environments:
 OFFLINE_MODE=true
 ```
 
-This disables HuggingFace Hub downloads, version update checks, and other outbound calls. Models and embeddings must be available locally.
+This disables HuggingFace Hub downloads, version update checks, and automatic updates of the embedding, reranking, and Whisper models. Models and embeddings must be available locally.
+
+Offline mode governs the connections Open WebUI makes on its own behalf. It does not block connections you configure, such as external model APIs, OAuth providers, web search, tool servers, or object storage. Isolating the instance at the network level is what closes those. See [`OFFLINE_MODE`](/reference/env-configuration#offline_mode) for the full list of what stays functional.
 
 ### SSRF prevention
 
@@ -830,7 +832,7 @@ For organizations where security is a priority, the following practices define t
 
 ### Outbound Network Controls
 
-11. **Keep SSRF protections, outbound TLS verification, and network restrictions enabled.** Do not enable local web fetch. The default configuration blocks access to private IP ranges and cloud provider metadata endpoints; extend the blocklist to include internal domains specific to your environment. Do not disable certificate verification for outbound connections. For air-gapped environments, enable offline mode to disable all outbound calls. [Details](#ssrf-prevention)
+11. **Keep SSRF protections, outbound TLS verification, and network restrictions enabled.** Do not enable local web fetch. The default configuration blocks access to private IP ranges and cloud provider metadata endpoints; extend the blocklist to include internal domains specific to your environment. Do not disable certificate verification for outbound connections. For air-gapped environments, enable offline mode so Open WebUI stops making its own outbound calls, and isolate the instance at the network level to close the connections it does not control. [Details](#ssrf-prevention)
 
 ### Supply Chain and Change Management
 

--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -2459,6 +2459,8 @@ If `OFFLINE_MODE` is enabled, this `ENABLE_VERSION_UPDATE_CHECK` flag is always 
 - Downloads of embedding models from Hugging Face Hub
   - If you did not download an embedding model prior to activating `OFFLINE_MODE` any RAG, web search and document analysis functionality may not work properly. On a **fresh install** this aborts startup with `No embedding model is loaded`, see [Startup & Docker Failures](/troubleshooting/startup#valueerror-no-embedding-model-is-loaded-with-offline-mode-on-a-fresh-install) for the fix.
 - Update notifications in the UI (see flag `ENABLE_VERSION_UPDATE_CHECK`)
+- Automatic updates of the embedding, reranking, and Whisper models
+- Installation of Python packages declared in function and tool `requirements` frontmatter, regardless of [`ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS`](#enable_pip_install_frontmatter_requirements). A plugin whose dependencies are not already present fails with `ModuleNotFoundError` when it loads, and the skip is only recorded in the logs, so pre-install the packages in your image.
 
 **Still functional:**
 
@@ -8396,6 +8398,8 @@ RUN pip install --no-cache-dir python-docx requests beautifulsoup4
 ```
 
 When disabled, functions and tools that import missing packages will fail with a `ModuleNotFoundError` at load time, clearly indicating which packages need to be pre-installed.
+
+[`OFFLINE_MODE`](#offline_mode) skips these installs as well, even when this variable is left enabled.
 
 :::
 


### PR DESCRIPTION
## Summary

`OFFLINE_MODE` is currently described in two ways that contradict each other, and one of its effects is not documented at all.

**The scope is overstated on the hardening page.** It says offline mode disables "other outbound calls" and, in the production checklist, that it disables "all outbound calls". The environment reference on the same site lists external LLM APIs, OAuth providers, and web search as still functional. A reader following the hardening page can reasonably conclude that setting one variable seals the instance, when the connections they configure themselves are untouched.

**The requirements skip is undocumented.** `OFFLINE_MODE` also skips installing the Python packages declared in function and tool `requirements` frontmatter, and it does so even when `ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS` is left enabled. Nothing on the site connects those two. The pages that document the auto-install attribute it to `ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS` alone and do not mention offline mode, and the offline mode pages never mention `requirements`. Anyone running custom Tools or Functions who enables offline mode gets a behavior change that only appears as an INFO log line, followed by a `ModuleNotFoundError` when the plugin loads.

This PR corrects the scope wording and documents the skip, without changing any behavior or recommending anything new.

## Related issue or discussion

None.

## Checklist

- [x] I have reviewed the relevant documentation and matched the existing style.
- [x] This PR meets Open WebUI's contribution standards: it is accurate, relevant to users, narrowly scoped, maintainable, and not promotional content, advertising, lead generation, SEO placement, or a request to list a product, service, provider, integration, gateway, tool, or company primarily for visibility.
- [x] I understand that PRs that do not meet these standards may be closed without review and will not be merged. Repeated, low-quality, off-topic, promotional, or intentionally misleading submissions may result in the contributor being blocked from future participation in Open WebUI repositories.

## Notes for reviewers

Every claim was checked against the code at tag `v0.11.3`, where `OFFLINE_MODE` appears in five files:

- `backend/open_webui/env.py:1180-1184` sets `HF_HUB_OFFLINE=1` and forces `ENABLE_VERSION_UPDATE_CHECK` off.
- `backend/open_webui/config.py:1008`, `:1035`, `:1551` gate the embedding, reranking, and Whisper auto-updates.
- `backend/open_webui/retrieval/utils.py:1691`, `:1719` force `local_files_only` for the embedding snapshot and re-raise instead of falling back.
- `backend/open_webui/utils/plugin.py:428` returns early from `install_frontmatter_requirements()`, after the `ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS` check, so offline mode skips the install independently of that variable. Called from `:225` (tools), `:275` (functions), and `:482` (startup).
- `backend/open_webui/utils/auth.py:27` imports the flag and never uses it.

Nothing gates web search, external model APIs, OAuth, tool servers, or object storage, which is why the wording moved to "the connections Open WebUI makes on its own behalf".

Two files change. The two links added point at anchors already used elsewhere in the docs, and `npx prettier --check` passes on both.
