### PR TITLE
docs: fix dead relative links on the creating files page

### DIFF
--- a/docs/features/open-terminal/use-cases/creating-files.md
+++ b/docs/features/open-terminal/use-cases/creating-files.md
@@ -39,7 +39,7 @@ The AI reads the data, builds the `.docx` with a heading, a summary paragraph an
 
 ![The AI generating a PDF and displaying it in the chat](/images/open-terminal-create-pdf.png)
 
-Long documents open at whichever page you ask for. See [Files shown in the chat message](../file-browser#files-shown-in-the-chat-message).
+Long documents open at whichever page you ask for. See [Files shown in the chat message](../file-browser.md#files-shown-in-the-chat-message).
 
 ---
 
@@ -89,7 +89,7 @@ Every file shown in the chat carries a **download button** in the top right of i
 
 ![The download button on a file shown in the chat](/images/open-terminal-inline-download-button.png)
 
-The file is also sitting in your workspace, so the [file browser](../file-browser) has it too, alongside everything else the AI has made. Asking for it in the chat just saves you going to look.
+The file is also sitting in your workspace, so the [file browser](../file-browser.md) has it too, alongside everything else the AI has made. Asking for it in the chat just saves you going to look.
 
 :::tip Ask for the format you want
 "as a Word document", "as a PDF", "as a deck", "as an SVG" all work in plain language. If you do not say, the AI usually picks Markdown, which is fine for reading and less useful for sending on.
@@ -99,5 +99,5 @@ The file is also sitting in your workspace, so the [file browser](../file-browse
 
 ## Related
 
-- [Analyze Documents & Data](./file-analysis)
-- [The File Browser](../file-browser)
+- [Analyze Documents & Data](./file-analysis.md)
+- [The File Browser](../file-browser.md)


### PR DESCRIPTION
## Summary

The four relative links on the Create Documents & Files page are dead when clicked. This adds the file extension to each one, which is the form Docusaurus resolves at build time.

Clicking **Files shown in the chat message** on that page currently lands on `/features/open-terminal/use-cases/file-browser`, which does not exist. The correct target is `/features/open-terminal/file-browser`, and that is exactly what the `href` in the HTML says.

Docusaurus renders the correct `href` for the server-side pass. The hydrated router then re-resolves the original relative path against the page URL rather than the file path, so a click navigates somewhere the markup never pointed:

```
../file-browser   ->  /features/open-terminal/use-cases/file-browser
./file-analysis   ->  /features/open-terminal/use-cases/creating-files/file-analysis
```

Adding the extension fixes it because the link is then resolved at build time and the router never re-resolves it. 109 links in this repo already use that form.

```diff
-Long documents open at whichever page you ask for. See [Files shown in the chat message](../file-browser#files-shown-in-the-chat-message).
+Long documents open at whichever page you ask for. See [Files shown in the chat message](../file-browser.md#files-shown-in-the-chat-message).
```

## Related issue or discussion

No linked issue. This corrects links on the page added in #1370.

## Checklist

- [x] I have reviewed the relevant documentation and matched the existing style.
- [x] This PR meets Open WebUI's contribution standards: it is accurate, relevant to users, narrowly scoped, maintainable, and not promotional content, advertising, lead generation, SEO placement, or a request to list a product, service, provider, integration, gateway, tool, or company primarily for visibility.
- [x] I understand that PRs that do not meet these standards may be closed without review and will not be merged. Repeated, low-quality, off-topic, promotional, or intentionally misleading submissions may result in the contributor being blocked from future participation in Open WebUI repositories.

## Notes for reviewers

**Reproducing it on the current site**

1. Open `https://docs.openwebui.com/features/open-terminal/use-cases/creating-files/`
2. Left click **Files shown in the chat message**
3. It renders Page Not Found

**Worth knowing before checking:** hovering, middle-clicking, and pasting the URL all work, because each of those uses the `href`, which is correct. Only a plain left click reproduces it.

That is also why the build does not catch this. `onBrokenLinks` is set to `throw` and passes, because it validates the rendered `href`. Setting `onBrokenMarkdownLinks` to `throw` would fail the build when an extension-form link loses its target, which is the check that catches this class of problem.

**Verification**

I ran `npm run build` and clicked all four links on the built site. Every one lands correctly, including the anchor:

| Link | Lands on |
|---|---|
| Files shown in the chat message | `/features/open-terminal/file-browser#files-shown-in-the-chat-message` |
| file browser | `/features/open-terminal/file-browser` |
| Analyze Documents & Data | `/features/open-terminal/use-cases/file-analysis` |
| The File Browser | `/features/open-terminal/file-browser` |

**Scope**

I kept this to the one page. The same pattern affects other pages across the docs, and I am reporting those separately with the full list rather than widening this PR.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed and manually tested it.
