### PR TITLE
docs: fail the build on broken Markdown file-path links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -51,6 +51,9 @@ const config: Config = {
 	// Enable Mermaid for diagrams
 	markdown: {
 		mermaid: true,
+		hooks: {
+			onBrokenMarkdownLinks: "throw",
+		},
 	},
 	clientModules: ["./src/clientModules/ensure-gtag.js"],
 	themes: [


### PR DESCRIPTION
## Summary

Makes the build fail when a Markdown link written as a file-path points at a file that does not exist. Follows #1373 and #1374, which converted 123 relative links to the file-path form.

```diff
 	markdown: {
 		mermaid: true,
+		hooks: {
+			onBrokenMarkdownLinks: "throw",
+		},
 	},
```

The default is `warn`, so a Markdown link whose target has moved or been renamed prints a line during the build and ships anyway. `onBrokenLinks` is already set to `throw`, but that validates the rendered `href` rather than the source link, so the two settings cover different things.

232 links now use the file-path form, up from 109 before #1374. That form is only worth adopting if a moved target is caught, which is what this changes.

## Related issue or discussion

No linked issue. Follows #1373 and #1374.

## Checklist

- [x] I have reviewed the relevant documentation and matched the existing style.
- [x] This PR meets Open WebUI's contribution standards: it is accurate, relevant to users, narrowly scoped, maintainable, and not promotional content, advertising, lead generation, SEO placement, or a request to list a product, service, provider, integration, gateway, tool, or company primarily for visibility.
- [x] I understand that PRs that do not meet these standards may be closed without review and will not be merged. Repeated, low-quality, off-topic, promotional, or intentionally misleading submissions may result in the contributor being blocked from future participation in Open WebUI repositories.

## Notes for reviewers

**What this catches, and what it does not**

I tested both link forms by pointing each at a file that does not exist and building.

| Probe | Source | Build result |
|---|---|---|
| A | `[probe a](./this-file-does-not-exist.mdx)` | fails, with the file and line number |
| B | `[probe b](./this-file-also-does-not-exist)` | passes, no message |

So this guards the file-path form and nothing else. It would **not** have caught the 123 dead links fixed in #1373 and #1374, because those were written without an extension and this hook never inspects that form. What it does is keep the fix from rotting. Those links are now file-path links, so a renamed or moved target will stop the build rather than reaching the site.

Probe A reports it like this, which is enough to fix without hunting:

```
Error: Markdown link with URL `./this-file-does-not-exist.mdx` in source file
"docs/troubleshooting/web-search.mdx" (128:46) couldn't be resolved.
```

**Config key**

The installed `@docusaurus/core` is 3.9.2. The top-level `siteConfig.onBrokenMarkdownLinks` is deprecated there and logs a migration warning, so this goes in `markdown.hooks` instead. The build confirms it, printing no deprecation warning.

**Verification**

`npm run build` on current `main` with this setting passes. 419 pages, no broken Markdown links surfaced, no deprecation warning. I then added the two probe links above, rebuilt to confirm the setting actually fires, and reverted them. The only change in this PR is the three config lines.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed and manually tested it.
