### PR TITLE
docs: add Hubris to OpenAI-compatible providers

### DIFF
--- a/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
+++ b/docs/getting-started/quick-start/connect-a-provider/starting-with-openai-compatible.mdx
@@ -269,6 +269,17 @@ Each connection has a **toggle switch** that lets you enable or disable it witho
   :::
 
   </TabItem>
+  <TabItem value="hubris" label="Hubris">
+
+  **Hubris** is a ruble-billed OpenAI-compatible LLM gateway offering 400+ models (OpenAI, Anthropic, Google, and more) behind one API key.
+
+  | Setting | Value |
+  |---|---|
+  | **URL** | `https://api.hubris.pw/v1` |
+  | **API Key** | Your API key from [hubris.pw/keys](https://hubris.pw/keys) |
+  | **Model IDs** | Auto-detected via `/models` |
+
+  </TabItem>
   <TabItem value="bedrock" label="Amazon Bedrock">
 
   **Amazon Bedrock** is a fully managed AWS service that provides access to foundation models from leading AI companies (Anthropic, Meta, Mistral, Cohere, Stability AI, Amazon, and more) through a single API.


### PR DESCRIPTION
Adds Hubris — a ruble-billed OpenAI-compatible LLM gateway (400+ models) — to the Cloud Providers tabs on the OpenAI-Compatible page, following the exact same format as the existing entries (DeepSeek/Mistral/Groq — working `/models` auto-detection, no special notes needed).

Small, atomic, docs-only change.