### PR TITLE
Correct the fresh-install note for OFFLINE_MODE: the container starts, the first embedding call fails

### DIFF
--- a/docs/reference/env-configuration.mdx
+++ b/docs/reference/env-configuration.mdx
@@ -2457,7 +2457,7 @@ If `OFFLINE_MODE` is enabled, this `ENABLE_VERSION_UPDATE_CHECK` flag is always 
 
 - Automatic version update checks (see flag `ENABLE_VERSION_UPDATE_CHECK`)
 - Downloads of embedding models from Hugging Face Hub
-  - If you did not download an embedding model prior to activating `OFFLINE_MODE` any RAG, web search and document analysis functionality may not work properly. On a **fresh install** this aborts startup with `No embedding model is loaded`, see [Startup & Docker Failures](/troubleshooting/startup#valueerror-no-embedding-model-is-loaded-with-offline-mode-on-a-fresh-install) for the fix.
+  - If you did not download an embedding model prior to activating `OFFLINE_MODE` any RAG, web search and document analysis functionality may not work properly. On a **fresh install** the container starts, and the first document upload or RAG query then fails with `No embedding model is loaded`, see [Startup & Docker Failures](/troubleshooting/startup#valueerror-no-embedding-model-is-loaded-with-offline-mode-on-a-fresh-install) for the fix.
 - Update notifications in the UI (see flag `ENABLE_VERSION_UPDATE_CHECK`)
 - Automatic updates of the embedding, reranking, and Whisper models
 - Installation of Python packages declared in function and tool `requirements` frontmatter, regardless of [`ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS`](#enable_pip_install_frontmatter_requirements). A plugin whose dependencies are not already present fails with `ModuleNotFoundError` when it loads, and the skip is only recorded in the logs, so pre-install the packages in your image.


### PR DESCRIPTION
## Summary

The `OFFLINE_MODE` reference entry says that on a fresh install the flag "aborts startup with `No embedding model is loaded`". That was the 0.9.6 behavior. Since 0.10.0 the container starts, and the failure surfaces on the first document upload or RAG query. The linked troubleshooting page already says so, and `initialize_runtime_config` in `main.py` catches the embedding load error and logs it rather than exiting. The two pages now agree.

## Related issue or discussion

None. One-line correction to match the troubleshooting page and the code.

## Checklist

- [x] I have reviewed the relevant documentation and matched the existing style.
- [x] This PR meets Open WebUI's contribution standards: it is accurate, relevant to users, narrowly scoped, maintainable, and not promotional content, advertising, lead generation, SEO placement, or a request to list a product, service, provider, integration, gateway, tool, or company primarily for visibility.
- [x] I understand that PRs that do not meet these standards may be closed without review and will not be merged. Repeated, low-quality, off-topic, promotional, or intentionally misleading submissions may result in the contributor being blocked from future participation in Open WebUI repositories.

## Notes for reviewers

The corrected sentence keeps the existing link to the troubleshooting entry. That entry reads "The container starts ... and the first document upload or RAG query then fails with the `ValueError`", and it notes that 0.9.6 aborted startup instead, fixed in 0.10.0. I started today's `:main` image with `OFFLINE_MODE=true` on an empty named volume, and the container reported healthy and kept running.
