### PR TITLE
docs: tools and tool-ids URL parameters need the prefixed ID for tool server connections

### DIFF
--- a/docs/features/chat-conversations/chat-features/url-params.md
+++ b/docs/features/chat-conversations/chat-features/url-params.md
@@ -16,7 +16,7 @@ The following table lists the available URL parameters, their function, and exam
 | `youtube`             | Specifies a YouTube video ID to be transcribed within the chat. | `/?youtube=VIDEO_ID`             |
 | `load-url`            | Specifies a Website URL to be fetched and uploaded as a document within the chat. | `/?load-url=https://google.com`  |
 | `web-search`          | Enables web search functionality if set to `true`. | `/?web-search=true`              |
-| `tools` or `tool-ids` | Specifies a comma-separated list of tool IDs to activate in the chat. | `/?tools=tool1,tool2`            |
+| `tools` or `tool-ids` | Specifies a comma-separated list of tool IDs to activate in the chat. Tool server connections use a prefixed ID. | `/?tools=tool1,tool2`            |
 | `call`                | Enables a call overlay if set to `true`. | `/?call=true`                    |
 | `q`                   | Sets an initial query or prompt for the chat. | `/?q=Hello%20there`              |
 | `temporary-chat`      | Marks the chat as temporary if set to `true`, for one-time sessions. | `/?temporary-chat=true`          |
@@ -59,6 +59,7 @@ The following table lists the available URL parameters, their function, and exam
 - **How to Set**: Provide a comma-separated list of tool IDs as the parameter’s value.
 - **Example**: `/?tools=tool1,tool2` or `/?tool-ids=tool1,tool2`
 - **Behavior**: Each tool ID is matched and activated within the session for user interaction.
+- **Note**: The value must be the ID Open WebUI uses internally, which is not always the name you see in the Integrations menu. A workspace tool uses its plain ID, for example `/?tools=my_workspace_tool`. A tool server connection carries a prefix in front of the ID set on the connection. Use `server:mcp:<server-id>` for an MCP connection and `server:<server-id>` for an OpenAPI connection, for example `/?tool-ids=server:mcp:my_mcp_server`. An OpenAPI connection with no ID set uses its position in the connections list, starting at `0`. An ID that matches nothing is not activated. The tools list endpoint returns the exact IDs, see [Using Open WebUI tools, including MCP, from the API](/reference/api-endpoints#using-open-webui-tools-including-mcp-from-the-api).
 
 ### 6. **Call Overlay**
 


### PR DESCRIPTION
## Summary

The URL Parameters page says `tools` and `tool-ids` take "tool IDs" and shows `tool1,tool2`. That works for workspace tools, whose ID is the plain ID. It does not work for tool server connections, because Open WebUI keys those as `server:mcp:<server-id>` for MCP connections and `server:<server-id>` for OpenAPI connections. Passing the bare connection ID activates nothing.

This PR adds a note under Tool Selection that spells out both forms with an example. It also covers the fallback for an OpenAPI connection without an ID and says that an unmatched ID is not activated. It links the API reference section that already documents the `server:mcp:` form. The overview table row gets one sentence so the prefix is visible at a glance.

## Related issue or discussion

The UI side of the same trip-up is open-webui/open-webui#29802: an unmatched ID from the URL shows a tool count of 1 with no tool selected.

## Checklist

- [x] I have reviewed the relevant documentation and matched the existing style.
- [x] This PR meets Open WebUI's contribution standards: it is accurate, relevant to users, narrowly scoped, maintainable, and not promotional content, advertising, lead generation, SEO placement, or a request to list a product, service, provider, integration, gateway, tool, or company primarily for visibility.
- [x] I understand that PRs that do not meet these standards may be closed without review and will not be merged. Repeated, low-quality, off-topic, promotional, or intentionally misleading submissions may result in the contributor being blocked from future participation in Open WebUI repositories.

## Notes for reviewers

I hit this tonight with `/?tool-ids=deepwiki` for an MCP connection whose ID is `deepwiki`. The chat input showed a tool count of 1, but the tool was not selected in the Integrations menu and opening the menu cleared the count. `server:mcp:deepwiki` is the value that parameter wants.

The ID forms come from `open-webui/open-webui` at `674760bfc1122e0a19fe299e05a86d1cbb528e6f`: OpenAPI connections at [`routers/tools.py#L117`](https://github.com/open-webui/open-webui/blob/674760bfc1122e0a19fe299e05a86d1cbb528e6f/backend/open_webui/routers/tools.py#L117), MCP connections at [`routers/tools.py#L153`](https://github.com/open-webui/open-webui/blob/674760bfc1122e0a19fe299e05a86d1cbb528e6f/backend/open_webui/routers/tools.py#L153), and the position fallback for an OpenAPI connection with no ID at [`utils/tools.py#L1535-L1537`](https://github.com/open-webui/open-webui/blob/674760bfc1122e0a19fe299e05a86d1cbb528e6f/backend/open_webui/utils/tools.py#L1535-L1537).

The linked anchor is the same one `docs/reference/server-side-tool-calling.md` already uses.
